### PR TITLE
Add interactiveOpponent to combo objects

### DIFF
--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -72,6 +72,8 @@ export type ConversionType = PlayerIndexedType & DurationType & DamageType & {
 export type ComboType = PlayerIndexedType & DurationType & DamageType & {
   moves: MoveLandedType[];
   didKill: boolean;
+  interactiveOpponent: boolean | null;
+  opponentInputs: boolean[];
 };
 
 export type ActionCountsType = PlayerIndexedType & {
@@ -213,4 +215,11 @@ export function calcDamageTaken(frame: PostFrameUpdateType, prevFrame: PostFrame
   const prevPercent = _.get(prevFrame, 'percent', 0);
 
   return percent - prevPercent;
+}
+
+export function isInputting(frame: PreFrameUpdateType, prevFrame: PreFrameUpdateType): boolean {
+  const inputKeys = ['buttons', 'joystickX', 'joystickY', 'cStickX', 'cStickY', 'trigger'];
+  const currentInputs = _.pick(frame, inputKeys);
+  const prevInputs = _.pick(prevFrame, inputKeys);
+  return !_.isEqual(currentInputs, prevInputs);
 }


### PR DESCRIPTION
provide a boolean that lets the user know if there were no inputs from the opponent at all.

Goal is to provide a way for users to know if they should filter combo because there was no interaction from the combo'd player (possibly because they were away from their controller)

This only covers the 0% change in inputs case. There is some discussion to be had about values between 0 and 100% that might be worth notifying the user about or if we should provide something else entirely.