### PR TITLE
Automatically populate metadata in SlpFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest --verbose",
     "coverage": "yarn run test -- --coverage",
     "postcoverage": "open-cli coverage/lcov-report/index.html",
-    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\"",
     "lint:fix": "yarn run lint --fix",
     "clean": "rimraf dist",
     "prebuild": "yarn run clean",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from "./stats";
 
 // Utils
 export * from "./utils/slpFile";
+export * from "./utils/slpFileWriter";
 export * from "./utils/slpStream";
 export * from "./utils/slpParser";
 

--- a/src/utils/slpFile.ts
+++ b/src/utils/slpFile.ts
@@ -34,7 +34,7 @@ export class SlpFile extends Writable {
    * @param {WritableOptions} [opts] Options for writing.
    * @memberof SlpFile
    */
-  public constructor(filePath: string, opts?: WritableOptions) {
+  public constructor(filePath: string, slpStream?: SlpStream, opts?: WritableOptions) {
     super(opts);
     this.filePath = filePath;
     this.metadata = {
@@ -43,8 +43,10 @@ export class SlpFile extends Writable {
       lastFrame: -124,
       players: {},
     };
+
+    // Create a new SlpStream if one wasn't already provided
     // This SLP stream represents a single game not multiple, so use manual mode
-    this.slpStream = new SlpStream({ mode: SlpStreamMode.MANUAL });
+    this.slpStream = slpStream ? slpStream : new SlpStream({ mode: SlpStreamMode.MANUAL });
 
     this._setupListeners();
     this._initializeNewGame(this.filePath);

--- a/src/utils/slpFile.ts
+++ b/src/utils/slpFile.ts
@@ -3,7 +3,7 @@ import fs, { WriteStream } from "fs";
 import moment, { Moment } from "moment";
 import { Writable, WritableOptions } from "stream";
 import { SlpStream, SlpStreamMode, SlpStreamEvent, SlpCommandEventPayload } from "./slpStream";
-import { Command, PostFrameUpdateType, EventPayloadTypes } from "../types";
+import { Command, PostFrameUpdateType } from "../types";
 
 const DEFAULT_NICKNAME = "unknown";
 
@@ -99,7 +99,7 @@ export class SlpFile extends Writable {
    *
    * @param data The parsed data from a SlpStream
    */
-  private _onCommand(data: SlpCommandEventPayload) {
+  private _onCommand(data: SlpCommandEventPayload): void {
     const { command, payload } = data;
     switch (command) {
       case Command.POST_FRAME_UPDATE:

--- a/src/utils/slpFile.ts
+++ b/src/utils/slpFile.ts
@@ -99,12 +99,10 @@ export class SlpFile extends Writable {
 
   /**
    * Sets the metadata of the Slippi file, such as consoleNickname, lastFrame, and players.
-   *
-   * @param {SlpFileMetadata} metadata The metadata to be written
-   * @memberof SlpFile
+   * @param metadata The metadata to be written
    */
-  public setMetadata(metadata: SlpFileMetadata): void {
-    this.metadata = metadata;
+  public setMetadata(metadata: Partial<SlpFileMetadata>): void {
+    this.metadata = Object.assign({}, this.metadata, metadata);
   }
 
   public _write(chunk: Uint8Array, encoding: string, callback: (error?: Error | null) => void): void {

--- a/src/utils/slpFile.ts
+++ b/src/utils/slpFile.ts
@@ -79,7 +79,7 @@ export class SlpFile extends Writable {
     // Write it to the file
     this.fileStream.write(chunk);
 
-    // Send through to the stream if it's not an external stream
+    // Parse the data manually if it's an internal stream
     if (!this.usesExternalStream) {
       this.slpStream.write(chunk);
     }

--- a/src/utils/slpFile.ts
+++ b/src/utils/slpFile.ts
@@ -121,9 +121,10 @@ export class SlpFile extends Writable {
   }
 
   private _setupListeners(): void {
-    this.slpStream.on(SlpStreamEvent.COMMAND, (data: SlpCommandEventPayload) => {
+    const streamListener = (data: SlpCommandEventPayload) => {
       this._onCommand(data);
-    });
+    };
+    this.slpStream.on(SlpStreamEvent.COMMAND, streamListener);
 
     this.on("finish", () => {
       // Update file with bytes written
@@ -131,8 +132,8 @@ export class SlpFile extends Writable {
       (fs as any).writeSync(fd, createUInt32Buffer(this.rawDataLength), 0, "binary", 11);
       fs.closeSync(fd);
 
-      // Mark the SlpStream as finished
-      this.slpStream.end();
+      // Unsubscribe from the stream
+      this.slpStream.removeListener(SlpStreamEvent.COMMAND, streamListener);
     });
   }
 

--- a/src/utils/slpFileWriter.ts
+++ b/src/utils/slpFileWriter.ts
@@ -1,0 +1,135 @@
+import path from "path";
+import moment, { Moment } from "moment";
+
+import { SlpFile } from "./slpFile";
+import { SlpStream, SlpStreamEvent, SlpRawEventPayload, SlpStreamSettings } from "./slpStream";
+import { Command } from "../types";
+import { WritableOptions } from "stream";
+
+/**
+ * The default function to use for generating new SLP files.
+ */
+function getNewFilePath(folder: string, m: Moment): string {
+  return path.join(folder, `Game_${m.format("YYYYMMDD")}T${m.format("HHmmss")}.slp`);
+}
+
+export interface SlpFileWriterOptions {
+  folderPath: string;
+  consoleNickname: string;
+  newFilename: (folder: string, startTime: Moment) => string;
+}
+
+const defaultSettings: SlpFileWriterOptions = {
+  folderPath: ".",
+  consoleNickname: "unknown",
+  newFilename: getNewFilePath,
+};
+
+export enum SlpFileWriterEvent {
+  NEW_FILE = "new-file",
+  FILE_COMPLETE = "file-complete",
+}
+
+/**
+ * SlpFileWriter lets us not only emit events as an SlpStream but also
+ * writes the data that is being passed in to an SLP file. Use this if
+ * you want to process Slippi data in real time but also want to be able
+ * to write out the data to an SLP file.
+ *
+ * @export
+ * @class SlpFileWriter
+ * @extends {SlpStream}
+ */
+export class SlpFileWriter extends SlpStream {
+  private currentFile: SlpFile | null;
+  private options: SlpFileWriterOptions;
+
+  /**
+   * Creates an instance of SlpFileWriter.
+   */
+  public constructor(
+    options?: Partial<SlpFileWriterOptions>,
+    slpOptions?: Partial<SlpStreamSettings>,
+    opts?: WritableOptions,
+  ) {
+    super(slpOptions, opts);
+    this.options = Object.assign({}, defaultSettings, options);
+    this._setupListeners();
+  }
+
+  private _writePayload(payload: Buffer): void {
+    // Write data to the current file
+    if (this.currentFile) {
+      this.currentFile.write(payload);
+    }
+  }
+
+  private _setupListeners(): void {
+    this.on(SlpStreamEvent.RAW, (data: SlpRawEventPayload) => {
+      const { command, payload } = data;
+      switch (command) {
+        case Command.MESSAGE_SIZES:
+          // Create the new game first before writing the payload
+          this._handleNewGame();
+          this._writePayload(payload);
+          break;
+        case Command.GAME_END:
+          // Write payload first before ending the game
+          this._writePayload(payload);
+          this._handleEndGame();
+          break;
+        default:
+          this._writePayload(payload);
+          break;
+      }
+    });
+  }
+
+  /**
+   * Return the name of the SLP file currently being written or null if
+   * no file is being written to currently.
+   *
+   * @returns {(string | null)}
+   * @memberof SlpFileWriter
+   */
+  public getCurrentFilename(): string | null {
+    if (this.currentFile !== null) {
+      return path.resolve(this.currentFile.path());
+    }
+    return null;
+  }
+
+  /**
+   * Updates the settings to be the desired ones passed in.
+   *
+   * @param {Partial<SlpFileWriterOptions>} settings
+   * @memberof SlpFileWriter
+   */
+  public updateSettings(settings: Partial<SlpFileWriterOptions>): void {
+    this.options = Object.assign({}, this.options, settings);
+  }
+
+  private _handleNewGame(): void {
+    const filePath = this.options.newFilename(this.options.folderPath, moment());
+    this.currentFile = new SlpFile(filePath, this);
+    // console.log(`Creating new file at: ${filePath}`);
+    this.emit(SlpFileWriterEvent.NEW_FILE, filePath);
+  }
+
+  private _handleEndGame(): void {
+    // End the stream
+    if (this.currentFile) {
+      // Set the console nickname
+      this.currentFile.setMetadata({
+        consoleNickname: this.options.consoleNickname,
+      });
+      this.currentFile.end();
+
+      // console.log(`Finished writing file: ${this.currentFile.path()}`);
+      this.emit(SlpFileWriterEvent.FILE_COMPLETE, this.currentFile.path());
+
+      // Clear current file
+      this.currentFile = null;
+    }
+  }
+}

--- a/src/utils/slpParser.ts
+++ b/src/utils/slpParser.ts
@@ -31,7 +31,7 @@ export class SlpParser extends EventEmitter {
   private settingsComplete = false;
   private lastFinalizedFrame = Frames.FIRST - 1;
 
-  public handleCommand(command: Command, payload: any) {
+  public handleCommand(command: Command, payload: any): void {
     switch (command) {
       case Command.GAME_START:
         this._handleGameStart(payload as GameStartType);
@@ -199,14 +199,14 @@ export class SlpParser extends EventEmitter {
    * Fires off the FINALIZED_FRAME event for frames up until a certain number
    * @param num The frame to finalize until
    */
-  private _finalizeFrames(num: number) {
+  private _finalizeFrames(num: number): void {
     while (this.lastFinalizedFrame < num) {
       this.lastFinalizedFrame++;
       this.emit(SlpParserEvent.FINALIZED_FRAME, this.getFrame(this.lastFinalizedFrame));
     }
   }
 
-  private _completeSettings() {
+  private _completeSettings(): void {
     if (!this.settingsComplete) {
       this.settingsComplete = true;
       this.emit(SlpParserEvent.SETTINGS, this.settings);

--- a/src/utils/slpStream.ts
+++ b/src/utils/slpStream.ts
@@ -60,7 +60,7 @@ export class SlpStream extends Writable {
     this.settings = Object.assign({}, defaultSettings, slpOptions);
   }
 
-  public restart() {
+  public restart(): void {
     this.gameEnded = false;
     this.payloadSizes = null;
     this.previousBuffer = Buffer.from([]);


### PR DESCRIPTION
Currently users of the `SlpFile` still need to manually populate the `players` field and `lastFrame` field in the file metadata. This PR changes that so that the metadata is populated automatically.

Naively, if the `SlpFile` simply once again parses the raw data that is being written, the data would be parsed multiple times. For example, the desktop app parses it once from the raw console, and then pipes the raw data to `SlpFile` which then parses it a second time to populate the metadata fields. This is not ideal. To solve this, we allow an optional `SlpStream` parameter to be passed into `SlpFile`. If provided, `SlpFile` will simply listen to the `slp-command` event of that `SlpStream` in order to populate the metadata. This ensures that the raw data will only be parsed once.

Additionally, this PR also adds a `SlpFileWriter` class which extends `SlpStream`. This provides the functionality of the `SlpStream` but also automatically creates new SLP files and writes the raw data to them. One simply has to define the output folder and console nickname, and optionally the file naming function as well. This greatly simplifies the code required for users who want to parse real time data, while also outputting SLP files.