### PR TITLE
Allow file writing to be enabled and disabled

### DIFF
--- a/src/utils/slpFileWriter.ts
+++ b/src/utils/slpFileWriter.ts
@@ -14,12 +14,14 @@ function getNewFilePath(folder: string, m: Moment): string {
 }
 
 export interface SlpFileWriterOptions {
+  outputFiles: boolean;
   folderPath: string;
   consoleNickname: string;
   newFilename: (folder: string, startTime: Moment) => string;
 }
 
 const defaultSettings: SlpFileWriterOptions = {
+  outputFiles: true,
   folderPath: ".",
   consoleNickname: "unknown",
   newFilename: getNewFilePath,
@@ -110,10 +112,13 @@ export class SlpFileWriter extends SlpStream {
   }
 
   private _handleNewGame(): void {
-    const filePath = this.options.newFilename(this.options.folderPath, moment());
-    this.currentFile = new SlpFile(filePath, this);
-    // console.log(`Creating new file at: ${filePath}`);
-    this.emit(SlpFileWriterEvent.NEW_FILE, filePath);
+    // Only create a new file if we're outputting files
+    if (this.options.outputFiles) {
+      const filePath = this.options.newFilename(this.options.folderPath, moment());
+      this.currentFile = new SlpFile(filePath, this);
+      // console.log(`Creating new file at: ${filePath}`);
+      this.emit(SlpFileWriterEvent.NEW_FILE, filePath);
+    }
   }
 
   private _handleEndGame(): void {


### PR DESCRIPTION
This PR allows the toggling of the actual file writing in `SlpFileWriter`. There may be a situations where you might not want some games to be recorded, but still want to have the option of enabling them again later. This change provides that flexibility. Games will still be written by default so no changes are required on the `slippi-desktop-app` side.

One can change the setting using:
```
stream.updateSettings({
  outputFiles: false,  // or true to enable
})
```

The change only takes effect on the next new game. Changing the setting in the middle of a current game will still continue to write the rest of the game to the existing file.