### PR TITLE
Fix minor issues SlpStream and SlpParser

### DIFF
--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -16,7 +16,6 @@ export interface FrameEntryType {
     };
   };
   items: ItemUpdateType[];
-  isTransferComplete: boolean;
 }
 
 export interface FramesType {

--- a/src/utils/slpParser.ts
+++ b/src/utils/slpParser.ts
@@ -208,11 +208,6 @@ export class SlpParser extends EventEmitter {
       const frameToFinalize = this.lastFinalizedFrame + 1;
       const frame = this.getFrame(frameToFinalize);
 
-      // Sanity check before finalizing frame
-      if (!frame.isTransferComplete) {
-        throw new Error(`Error finalizing frame ${frameToFinalize} of ${num}: isTransferComplete is false`);
-      }
-
       // Check that we have all the pre and post frame data for all players
       for (const player of this.settings.players) {
         const { pre, post } = frame.players[player.playerIndex];

--- a/src/utils/slpParser.ts
+++ b/src/utils/slpParser.ts
@@ -188,6 +188,10 @@ export class SlpParser extends EventEmitter {
     // Finalize frames if necessary
     const validLatestFrame = this.settings.gameMode === GameMode.ONLINE;
     if (validLatestFrame && latestFinalizedFrame >= Frames.FIRST) {
+      // Ensure valid latestFinalizedFrame
+      if (latestFinalizedFrame < frame - MAX_ROLLBACK_FRAMES) {
+        throw new Error(`latestFinalizedFrame should be within ${MAX_ROLLBACK_FRAMES} frames of ${frame}`);
+      }
       this._finalizeFrames(latestFinalizedFrame);
     } else {
       // Since we don't have a valid finalized frame, just finalize the frame based on MAX_ROLLBACK_FRAMES
@@ -201,8 +205,28 @@ export class SlpParser extends EventEmitter {
    */
   private _finalizeFrames(num: number): void {
     while (this.lastFinalizedFrame < num) {
-      this.lastFinalizedFrame++;
-      this.emit(SlpParserEvent.FINALIZED_FRAME, this.getFrame(this.lastFinalizedFrame));
+      const frameToFinalize = this.lastFinalizedFrame + 1;
+      const frame = this.getFrame(frameToFinalize);
+
+      // Sanity check before finalizing frame
+      if (!frame.isTransferComplete) {
+        throw new Error(`Error finalizing frame ${frameToFinalize} of ${num}: isTransferComplete is false`);
+      }
+
+      // Check that we have all the pre and post frame data for all players
+      for (const player of this.settings.players) {
+        const { pre, post } = frame.players[player.playerIndex];
+        if (!pre || !post) {
+          const preOrPost = pre ? "pre" : "post";
+          throw new Error(
+            `Error finalizing frame ${frameToFinalize} of ${num}: missing ${preOrPost}-frame update for player ${player.playerIndex}`,
+          );
+        }
+      }
+
+      // Our frame is complete so finalize the frame
+      this.emit(SlpParserEvent.FINALIZED_FRAME, frame);
+      this.lastFinalizedFrame = frameToFinalize;
     }
   }
 

--- a/src/utils/slpParser.ts
+++ b/src/utils/slpParser.ts
@@ -214,7 +214,7 @@ export class SlpParser extends EventEmitter {
         if (!pre || !post) {
           const preOrPost = pre ? "pre" : "post";
           throw new Error(
-            `Error finalizing frame ${frameToFinalize} of ${num}: missing ${preOrPost}-frame update for player ${player.playerIndex}`,
+            `Could not finalize frame ${frameToFinalize} of ${num}: missing ${preOrPost}-frame update for player ${player.playerIndex}`,
           );
         }
       }

--- a/src/utils/slpStream.ts
+++ b/src/utils/slpStream.ts
@@ -44,7 +44,7 @@ export enum SlpStreamEvent {
  * @extends {Writable}
  */
 export class SlpStream extends Writable {
-  private gameEnded = false;
+  private gameEnded = false; // True only if in manual mode and the game has completed
   private settings: SlpStreamSettings;
   private payloadSizes: MessageSizes | null = null;
   private previousBuffer: Uint8Array = Buffer.from([]);
@@ -63,7 +63,6 @@ export class SlpStream extends Writable {
   public restart(): void {
     this.gameEnded = false;
     this.payloadSizes = null;
-    this.previousBuffer = Buffer.from([]);
   }
 
   public _write(newData: Buffer, encoding: string, callback: (error?: Error | null, data?: any) => void): void {
@@ -166,11 +165,12 @@ export class SlpStream extends Writable {
 
     switch (command) {
       case Command.GAME_END:
-        // Reset players
-        this.payloadSizes = null;
         // Stop parsing data until we manually restart the stream
         if (this.settings.mode === SlpStreamMode.MANUAL) {
           this.gameEnded = true;
+        } else {
+          // We're in auto-mode so reset the payload sizes for the next game
+          this.payloadSizes = null;
         }
         break;
     }

--- a/src/utils/slpStream.ts
+++ b/src/utils/slpStream.ts
@@ -71,12 +71,6 @@ export class SlpStream extends Writable {
       throw new Error(`Unsupported stream encoding. Expected 'buffer' got '${encoding}'.`);
     }
 
-    if (this.settings.mode === SlpStreamMode.MANUAL && this.gameEnded) {
-      // We're in manual mode and the game has already ended so just return immediately
-      callback();
-      return;
-    }
-
     // Join the current data with the old data
     const data = Uint8Array.from(Buffer.concat([this.previousBuffer, newData]));
 
@@ -102,6 +96,11 @@ export class SlpStream extends Writable {
         // If remaining length is not long enough for full payload, save the remaining
         // data until we receive more data. The data has been split up.
         this.previousBuffer = data.slice(index);
+        break;
+      }
+
+      // Only process if the game is still going
+      if (this.settings.mode === SlpStreamMode.MANUAL && this.gameEnded) {
         break;
       }
 

--- a/test/realtime.spec.ts
+++ b/test/realtime.spec.ts
@@ -49,8 +49,7 @@ describe("when reading last finalised frame from SlpStream", () => {
 
     parser.on(SlpParserEvent.FINALIZED_FRAME, (frameEntry: FrameEntryType) => {
       expect(frameEntry).toBeTruthy();
-      const { frame, isTransferComplete } = frameEntry;
-      expect(isTransferComplete).toBeTruthy();
+      const { frame } = frameEntry;
       // We should never receive the same frame twice
       expect(frame).not.toEqual(parserLastFinalizedFrame);
       // The frame should monotonically increase


### PR DESCRIPTION
This PR includes the following changes:

* `SlpStream` should only auto-reset the message sizes field when in auto-mode but it was being reset all the time
* `SlpStream` should check for game completion inside the command loop, not the initial write function. Otherwise it would still end up processing data, right after game has ended.
* `SlpParser` should be more stringent when reading new frame data so we add more validity checks. `SlpParser` knows what fields to expect and when, and different applications are built on top of `SlpParser`'s finalized frame event. So if invalid data is provided to the parser, it should throw earlier rather than later so that applications built on top of `SlpParser` can just trust the event data.
* remove `isTransferComplete` field from `FrameEntryType` since it's not guaranteed to be populated