### PR TITLE
Added analog metrics.

### DIFF
--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -83,6 +83,9 @@ export interface OverallType extends PlayerIndexedType {
   successfulConversions: RatioType;
   inputsPerMinute: RatioType;
   digitalInputsPerMinute: RatioType;
+  joystickDistanceTraveled: number;
+  joystickMetersTraveled: number;
+  joystickAverageVelocity: RatioType;
   openingsPerKill: RatioType;
   damagePerOpening: RatioType;
   neutralWinRatio: RatioType;

--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -75,6 +75,7 @@ export interface InputCountsType {
   total: number;
 }
 
+export interface AnalogMotionType {
   distanceTraveled: number;
   metersTraveled: number;
   analogMotionFrameCount: number;

--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -75,6 +75,12 @@ export interface InputCountsType {
   total: number;
 }
 
+  distanceTraveled: number;
+  metersTraveled: number;
+  analogMotionFrameCount: number;
+  averageVelocity: RatioType;
+}
+
 export interface OverallType extends PlayerIndexedType {
   inputCounts: InputCountsType;
   conversionCount: number;
@@ -83,9 +89,7 @@ export interface OverallType extends PlayerIndexedType {
   successfulConversions: RatioType;
   inputsPerMinute: RatioType;
   digitalInputsPerMinute: RatioType;
-  joystickDistanceTraveled: number;
-  joystickMetersTraveled: number;
-  joystickAverageVelocity: RatioType;
+  joystickMotion: AnalogMotionType;
   openingsPerKill: RatioType;
   damagePerOpening: RatioType;
   neutralWinRatio: RatioType;

--- a/src/stats/inputs.ts
+++ b/src/stats/inputs.ts
@@ -25,6 +25,7 @@ export interface PlayerInput {
   buttonInputCount: number;
   triggerInputCount: number;
   joystickDistanceTraveled: number;
+  joystickMotionFrameCount: number;
 }
 
 export class InputComputer implements StatComputer<PlayerInput[]> {
@@ -43,6 +44,7 @@ export class InputComputer implements StatComputer<PlayerInput[]> {
         buttonInputCount: 0,
         triggerInputCount: 0,
         joystickDistanceTraveled: 0,
+        joystickMotionFrameCount: 0,
       };
       this.state.set(indices, playerState);
     });
@@ -122,7 +124,12 @@ function handleInputCompute(
   // be converted into meters, provided the controller being used has a standard gamecube stick.
   const deltaX = playerFrame.joystickX - prevPlayerFrame.joystickX;
   const deltaY = playerFrame.joystickY - prevPlayerFrame.joystickY;
-  state.joystickDistanceTraveled += getJoystickAnalogDistance(deltaX, deltaY);
+  const joystickDistance = getJoystickAnalogDistance(deltaX, deltaY);
+  state.joystickDistanceTraveled += joystickDistance;
+  if(joystickDistance > .001)
+  {
+  	state.joystickMotionFrameCount += 1;
+  }
 }
 
 function countSetBits(x: number): number {

--- a/src/stats/inputs.ts
+++ b/src/stats/inputs.ts
@@ -24,6 +24,7 @@ export interface PlayerInput {
   cstickInputCount: number;
   buttonInputCount: number;
   triggerInputCount: number;
+  joystickDistanceTraveled: number;
 }
 
 export class InputComputer implements StatComputer<PlayerInput[]> {
@@ -41,6 +42,7 @@ export class InputComputer implements StatComputer<PlayerInput[]> {
         cstickInputCount: 0,
         buttonInputCount: 0,
         triggerInputCount: 0,
+        joystickDistanceTraveled: 0,
       };
       this.state.set(indices, playerState);
     });
@@ -115,6 +117,12 @@ function handleInputCompute(
     state.inputCount += 1;
     state.triggerInputCount += 1;
   }
+
+  // Track the distance that the joystick has traveled. These are in unit coordinates and can
+  // be converted into meters, provided the controller being used has a standard gamecube stick.
+  const deltaX = playerFrame.joystickX - prevPlayerFrame.joystickX;
+  const deltaY = playerFrame.joystickY - prevPlayerFrame.joystickY;
+  state.joystickDistanceTraveled += getJoystickAnalogDistance(deltaX, deltaY);
 }
 
 function countSetBits(x: number): number {
@@ -129,6 +137,10 @@ function countSetBits(x: number): number {
     bits &= bits - 1;
   }
   return count;
+}
+
+function getJoystickAnalogDistance(x: number, y: number): number {
+  return Math.sqrt(x * x + y * y)
 }
 
 function getJoystickRegion(x: number, y: number): JoystickRegion {

--- a/src/stats/overall.ts
+++ b/src/stats/overall.ts
@@ -45,6 +45,11 @@ export function generateOverallStats(
     const totalDamage = _.sumBy(opponentStocks, "currentPercent") || 0;
     const killCount = opponentEndedStocks.length;
 
+    const analogDistance = _.get(playerInputs, "joystickDistanceTraveled");
+    // Distance from stick top to gyro center is ~2cm. Distance from center to edge of gate is ~.47 rad.
+    // If there are more detailed measurements that have been taken, this is the place to use them.
+    const metersTraveled = analogDistance * (.02 * .47);
+
     return {
       playerIndex: playerIndex,
       opponentIndex: opponentIndex,
@@ -56,6 +61,9 @@ export function generateOverallStats(
       successfulConversions: getRatio(successfulConversionCount, conversionCount),
       inputsPerMinute: getRatio(inputCounts.total, gameMinutes),
       digitalInputsPerMinute: getRatio(inputCounts.buttons, gameMinutes),
+      joystickDistanceTraveled: analogDistance,
+      joystickMetersTraveled: metersTraveled,
+      joystickAverageVelocity: getRatio(metersTraveled, gameMinutes * 60),
       openingsPerKill: getRatio(conversionCount, killCount),
       damagePerOpening: getRatio(totalDamage, conversionCount),
       neutralWinRatio: getOpeningRatio(conversionsByPlayerByOpening, playerIndex, opponentIndex, "neutral-win"),


### PR DESCRIPTION
Added in tracking the analog distance for the joystick in addition to computing the distance traveled in meters and the average velocity of the stick throughout the game. Analog distance is measured in joystick coordinate units while meters and meters per second are used for the real world distances. After looking at the average velocity, it's not as interesting as a metric as I initially thought it'd be. It's pretty low just due to the fact that in general, more frames are spent holding a direction than moving it. Maybe it'd be more interesting to track joystick acceleration or to exclude frames that don't have any movement? Eh.