### PR TITLE
Dynamically import enet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slippi/slippi-js",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Official Project Slippi Javascript SDK",
   "license": "LGPL-3.0-or-later",
   "repository": "project-slippi/slippi-js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,17 +2,15 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "./dist",
-    "module": "es6",
+    "module": "esnext",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "outDir": "./dist",
-    "target": "es5",
-    "esModuleInterop": true
+    "target": "es2018",
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "lib": ["esnext"]
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
The `enet` package was being imported and executed regardless of whether `DolphinConnection` was being used or not. This broke compatibility with the browser, and also causes strange messages to be logged whenever errors were thrown.

e.g. 
![image](https://i.imgur.com/38de6uO.png)

This PR makes it so that we only dynamically import the `enet` package when we actually attempt to connect to Dolphin. The connect interface has been changed to return a promise.