### PR TITLE
Add missing fields to MetadataType interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,7 @@ export interface MetadataType {
       };
     };
   } | null;
+  consoleNick?: string | null;
 }
 
 export type EventPayloadTypes =

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,6 +127,10 @@ export interface MetadataType {
       characters: {
         [internalCharacterId: number]: number;
       };
+      names?: {
+        netplay?: string | null;
+        code?: string | null;
+      };
     };
   } | null;
 }

--- a/test/game.spec.ts
+++ b/test/game.spec.ts
@@ -71,6 +71,15 @@ it("should be able to read nametags", () => {
   expect(settings3.players[1].nametag).toBe(".  。");
 });
 
+it("should be able to read netplay names and codes", () => {
+  const game = new SlippiGame("slp/finalizedFrame.slp");
+  const metadata = game.getMetadata();
+  expect(metadata.players[0].names.netplay).toBe("V");
+  expect(metadata.players[0].names.code).toBe("VA#0");
+  expect(metadata.players[1].names.netplay).toBe("Fizzi");
+  expect(metadata.players[1].names.code).toBe("FIZZI#36");
+});
+
 it("should support PAL version", () => {
   const palGame = new SlippiGame("slp/pal.slp");
   const ntscGame = new SlippiGame("slp/ntsc.slp");

--- a/test/game.spec.ts
+++ b/test/game.spec.ts
@@ -80,6 +80,12 @@ it("should be able to read netplay names and codes", () => {
   expect(metadata.players[1].names.code).toBe("FIZZI#36");
 });
 
+it("should be able to read console nickname", () => {
+  const game = new SlippiGame("slp/realtimeTest.slp");
+  const metadata = game.getMetadata().consoleNick;
+  expect(game.getMetadata().consoleNick).toBe("Day 1");
+});
+
 it("should support PAL version", () => {
   const palGame = new SlippiGame("slp/pal.slp");
   const ntscGame = new SlippiGame("slp/ntsc.slp");


### PR DESCRIPTION
MetadataType.players[].names appears in replay files from netplay and is documented in the [replay spec](https://github.com/project-slippi/slippi-wiki/blob/master/SPEC.md#players-metadata), but does not appear in the MetadataType interface.

Add the field to the interface and add a test to read it