### PR TITLE
test for SlippiGame.getFilePath

### DIFF
--- a/test/game.spec.ts
+++ b/test/game.spec.ts
@@ -46,6 +46,14 @@ it("should correctly return metadata", () => {
   expect(metadata.playedOn).toBe("dolphin");
 });
 
+it("should correctly return file path", () => {
+  const game = new SlippiGame("slp/test.slp");
+  expect(game.getFilePath()).toBe("slp/test.slp");
+
+  const empty_game = new SlippiGame(new Buffer(""));
+  expect(empty_game.getFilePath()).toBe(null);
+});
+
 it("should be able to read incomplete SLP files", () => {
   const game = new SlippiGame("slp/incomplete.slp");
   const settings = game.getSettings();


### PR DESCRIPTION
I looked at coveralls and noticed this method isn't covered
https://coveralls.io/builds/38798115/source?filename=src%2FSlippiGame.ts#L168

<img width="1122" alt="image" src="https://user-images.githubusercontent.com/5882512/114889784-06562780-9dd0-11eb-8c24-f99f112ef617.png">
