### PR TITLE
Revert "Doubles Stats (#54)"

### DIFF
--- a/src/SlippiGame.ts
+++ b/src/SlippiGame.ts
@@ -5,6 +5,7 @@ import {
   ComboComputer,
   ConversionComputer,
   generateOverallStats,
+  getSinglesPlayerPermutationsFromSettings,
   InputComputer,
   StatOptions,
   Stats,
@@ -130,8 +131,9 @@ export class SlippiGame {
     const inputs = this.inputComputer.fetch();
     const stocks = this.stockComputer.fetch();
     const conversions = this.conversionComputer.fetch();
+    const indices = getSinglesPlayerPermutationsFromSettings(settings);
     const playableFrames = this.parser.getPlayableFrameCount();
-    const overall = generateOverallStats(settings, inputs, stocks, conversions, playableFrames);
+    const overall = generateOverallStats(indices, inputs, stocks, conversions, playableFrames);
 
     const stats = {
       lastFrame: this.parser.getLatestFrameNumber(),

--- a/src/SlippiGame.ts
+++ b/src/SlippiGame.ts
@@ -5,7 +5,6 @@ import {
   ComboComputer,
   ConversionComputer,
   generateOverallStats,
-  getSinglesPlayerPermutationsFromSettings,
   InputComputer,
   StatOptions,
   Stats,
@@ -131,9 +130,8 @@ export class SlippiGame {
     const inputs = this.inputComputer.fetch();
     const stocks = this.stockComputer.fetch();
     const conversions = this.conversionComputer.fetch();
-    const indices = getSinglesPlayerPermutationsFromSettings(settings);
     const playableFrames = this.parser.getPlayableFrameCount();
-    const overall = generateOverallStats(indices, inputs, stocks, conversions, playableFrames);
+    const overall = generateOverallStats(settings, inputs, stocks, conversions, playableFrames);
 
     const stats = {
       lastFrame: this.parser.getLatestFrameNumber(),

--- a/src/stats/overall.ts
+++ b/src/stats/overall.ts
@@ -1,6 +1,14 @@
 import _ from "lodash";
 
-import { ConversionType, InputCountsType, OverallType, PlayerIndexedType, RatioType, StockType } from "./common";
+import { GameStartType } from "../types";
+import {
+  ConversionType,
+  getSinglesPlayerPermutationsFromSettings,
+  InputCountsType,
+  OverallType,
+  RatioType,
+  StockType,
+} from "./common";
 import { PlayerInput } from "./inputs";
 
 interface ConversionsByPlayerByOpening {
@@ -10,7 +18,7 @@ interface ConversionsByPlayerByOpening {
 }
 
 export function generateOverallStats(
-  playerIndices: PlayerIndexedType[],
+  settings: GameStartType,
   inputs: PlayerInput[],
   stocks: StockType[],
   conversions: ConversionType[],
@@ -25,6 +33,7 @@ export function generateOverallStats(
 
   const gameMinutes = playableFrameCount / 3600;
 
+  const playerIndices = getSinglesPlayerPermutationsFromSettings(settings);
   const overall = playerIndices.map((indices) => {
     const playerIndex = indices.playerIndex;
     const opponentIndex = indices.opponentIndex;

--- a/src/stats/overall.ts
+++ b/src/stats/overall.ts
@@ -1,7 +1,6 @@
 import _ from "lodash";
 
-import { GameStartType } from "../types";
-import { ConversionType, InputCountsType, OverallType, RatioType, StockType } from "./common";
+import { ConversionType, InputCountsType, OverallType, PlayerIndexedType, RatioType, StockType } from "./common";
 import { PlayerInput } from "./inputs";
 
 interface ConversionsByPlayerByOpening {
@@ -11,24 +10,24 @@ interface ConversionsByPlayerByOpening {
 }
 
 export function generateOverallStats(
-  settings: GameStartType,
+  playerIndices: PlayerIndexedType[],
   inputs: PlayerInput[],
   stocks: StockType[],
   conversions: ConversionType[],
   playableFrameCount: number,
 ): OverallType[] {
   const inputsByPlayer = _.keyBy(inputs, "playerIndex");
-  const originalConversions = conversions;
-  const conversionsByPlayer = _.groupBy(conversions, (conv) => conv.moves[0]?.playerIndex);
+  const stocksByPlayer = _.groupBy(stocks, "playerIndex");
+  const conversionsByPlayer = _.groupBy(conversions, "playerIndex");
   const conversionsByPlayerByOpening: ConversionsByPlayerByOpening = _.mapValues(conversionsByPlayer, (conversions) =>
     _.groupBy(conversions, "openingType"),
   );
 
   const gameMinutes = playableFrameCount / 3600;
 
-  const overall = settings.players.map((player) => {
-    const playerIndex = player.playerIndex;
-
+  const overall = playerIndices.map((indices) => {
+    const playerIndex = indices.playerIndex;
+    const opponentIndex = indices.opponentIndex;
     const playerInputs = _.get(inputsByPlayer, playerIndex) || {};
     const inputCounts: InputCountsType = {
       buttons: _.get(playerInputs, "buttonInputCount"),
@@ -37,49 +36,21 @@ export function generateOverallStats(
       joystick: _.get(playerInputs, "joystickInputCount"),
       total: _.get(playerInputs, "inputCount"),
     };
-    // const conversions = _.get(conversionsByPlayer, playerIndex) || [];
-    // const successfulConversions = conversions.filter((conversion) => conversion.moves.length > 1);
-    let conversionCount = 0;
-    let successfulConversionCount = 0;
 
-    const opponentIndices = settings.players
-      .filter((opp) => {
-        // We want players which aren't ourselves
-        if (opp.playerIndex === playerIndex) {
-          return false;
-        }
+    const conversions = _.get(conversionsByPlayer, playerIndex) || [];
+    const successfulConversions = conversions.filter((conversion) => conversion.moves.length > 1);
+    const opponentStocks = _.get(stocksByPlayer, opponentIndex) || [];
+    const opponentEndedStocks = _.filter(opponentStocks, "endFrame");
 
-        // Make sure they're not on our team either
-        return !settings.isTeams || opp.teamId !== player.teamId;
-      })
-      .map((opp) => opp.playerIndex);
-
-    let totalDamage = 0;
-    let killCount = 0;
-
-    // These are the conversions that we did on our opponents
-    originalConversions
-      // Filter down to conversions of our opponent
-      .filter((conversion) => conversion.playerIndex !== playerIndex)
-      .forEach((conversion) => {
-        conversionCount++;
-
-        // We killed the opponent
-        if (conversion.didKill && conversion.lastHitBy === playerIndex) {
-          killCount += 1;
-        }
-        if (conversion.moves.length > 1 && conversion.moves[0].playerIndex === playerIndex) {
-          successfulConversionCount++;
-        }
-        conversion.moves.forEach((move) => {
-          if (move.playerIndex === playerIndex) {
-            totalDamage += move.damage;
-          }
-        });
-      });
+    const conversionCount = conversions.length;
+    const successfulConversionCount = successfulConversions.length;
+    const totalDamage =
+      _.sumBy(conversions, (conversion) => conversion.moves.reduce((total, move) => total + move.damage, 0)) || 0;
+    const killCount = opponentEndedStocks.length;
 
     return {
       playerIndex: playerIndex,
+      opponentIndex: opponentIndex,
       inputCounts: inputCounts,
       conversionCount: conversionCount,
       totalDamage: totalDamage,
@@ -90,9 +61,9 @@ export function generateOverallStats(
       digitalInputsPerMinute: getRatio(inputCounts.buttons, gameMinutes),
       openingsPerKill: getRatio(conversionCount, killCount),
       damagePerOpening: getRatio(totalDamage, conversionCount),
-      neutralWinRatio: getOpeningRatio(conversionsByPlayerByOpening, playerIndex, opponentIndices, "neutral-win"),
-      counterHitRatio: getOpeningRatio(conversionsByPlayerByOpening, playerIndex, opponentIndices, "counter-attack"),
-      beneficialTradeRatio: getBeneficialTradeRatio(conversionsByPlayerByOpening, playerIndex, opponentIndices),
+      neutralWinRatio: getOpeningRatio(conversionsByPlayerByOpening, playerIndex, opponentIndex, "neutral-win"),
+      counterHitRatio: getOpeningRatio(conversionsByPlayerByOpening, playerIndex, opponentIndex, "counter-attack"),
+      beneficialTradeRatio: getBeneficialTradeRatio(conversionsByPlayerByOpening, playerIndex, opponentIndex),
     };
   });
 
@@ -110,14 +81,12 @@ function getRatio(count: number, total: number): RatioType {
 function getOpeningRatio(
   conversionsByPlayerByOpening: ConversionsByPlayerByOpening,
   playerIndex: number,
-  opponentIndices: number[],
+  opponentIndex: number,
   type: string,
 ): RatioType {
   const openings = _.get(conversionsByPlayerByOpening, [playerIndex, type]) || [];
 
-  const opponentOpenings = _.flatten(
-    opponentIndices.map((opponentIndex) => _.get(conversionsByPlayerByOpening, [opponentIndex, type]) || []),
-  );
+  const opponentOpenings = _.get(conversionsByPlayerByOpening, [opponentIndex, type]) || [];
 
   return getRatio(openings.length, openings.length + opponentOpenings.length);
 }
@@ -125,12 +94,10 @@ function getOpeningRatio(
 function getBeneficialTradeRatio(
   conversionsByPlayerByOpening: ConversionsByPlayerByOpening,
   playerIndex: number,
-  opponentIndices: number[],
+  opponentIndex: number,
 ): RatioType {
   const playerTrades = _.get(conversionsByPlayerByOpening, [playerIndex, "trade"]) || [];
-  const opponentTrades = _.flatten(
-    opponentIndices.map((opponentIndex) => _.get(conversionsByPlayerByOpening, [opponentIndex, "trade"]) || []),
-  );
+  const opponentTrades = _.get(conversionsByPlayerByOpening, [opponentIndex, "trade"]) || [];
 
   const benefitsPlayer = [];
 
@@ -139,15 +106,13 @@ function getBeneficialTradeRatio(
   zippedTrades.forEach((conversionPair) => {
     const playerConversion = _.first(conversionPair);
     const opponentConversion = _.last(conversionPair);
-    if (playerConversion && opponentConversion) {
-      const playerDamage = playerConversion.currentPercent - playerConversion.startPercent;
-      const opponentDamage = opponentConversion.currentPercent - opponentConversion.startPercent;
+    const playerDamage = playerConversion!.currentPercent - playerConversion!.startPercent;
+    const opponentDamage = opponentConversion!.currentPercent - opponentConversion!.startPercent;
 
-      if (playerConversion!.didKill && !opponentConversion!.didKill) {
-        benefitsPlayer.push(playerConversion);
-      } else if (playerDamage > opponentDamage) {
-        benefitsPlayer.push(playerConversion);
-      }
+    if (playerConversion!.didKill && !opponentConversion!.didKill) {
+      benefitsPlayer.push(playerConversion);
+    } else if (playerDamage > opponentDamage) {
+      benefitsPlayer.push(playerConversion);
     }
   });
 

--- a/test/conversion.spec.ts
+++ b/test/conversion.spec.ts
@@ -7,7 +7,7 @@ describe("when calculating conversions", () => {
     const puff = stats.overall[0];
     let totalDamagePuffDealt = 0;
     stats.conversions.forEach((conversion) => {
-      if (conversion.lastHitBy === puff.playerIndex) {
+      if (conversion.playerIndex === puff.playerIndex) {
         totalDamagePuffDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
       }
     });
@@ -22,7 +22,7 @@ describe("when calculating conversions", () => {
     const bowser = stats.overall[0];
     let totalDamageBowserDealt = 0;
     stats.conversions.forEach((conversion) => {
-      if (conversion.lastHitBy === bowser.playerIndex) {
+      if (conversion.playerIndex === bowser.playerIndex) {
         totalDamageBowserDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
       }
     });
@@ -39,7 +39,7 @@ describe("when calculating conversions", () => {
     const falcon = stats.overall[0];
     let totalDamageFalconDealt = 0;
     stats.conversions.forEach((conversion) => {
-      if (conversion.lastHitBy === falcon.playerIndex) {
+      if (conversion.playerIndex === falcon.playerIndex) {
         totalDamageFalconDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
       }
     });
@@ -54,7 +54,7 @@ describe("when calculating conversions", () => {
     const ganon = stats.overall[0];
     let totalDamageGanonDealt = 0;
     stats.conversions.forEach((conversion) => {
-      if (conversion.lastHitBy === ganon.playerIndex) {
+      if (conversion.playerIndex === ganon.playerIndex) {
         totalDamageGanonDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
       }
     });
@@ -69,7 +69,7 @@ describe("when calculating conversions", () => {
     const kirby = stats.overall[0];
     let totalDamageKirbyDealt = 0;
     stats.conversions.forEach((conversion) => {
-      if (conversion.lastHitBy === kirby.playerIndex) {
+      if (conversion.playerIndex === kirby.playerIndex) {
         totalDamageKirbyDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
       }
     });
@@ -84,7 +84,7 @@ describe("when calculating conversions", () => {
     const yoshi = stats.overall[0];
     let totalDamageYoshiDealt = 0;
     stats.conversions.forEach((conversion) => {
-      if (conversion.lastHitBy === yoshi.playerIndex) {
+      if (conversion.playerIndex === yoshi.playerIndex) {
         totalDamageYoshiDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
       }
     });
@@ -99,7 +99,7 @@ describe("when calculating conversions", () => {
     const mewTwo = stats.overall[0];
     let totalDamageMewTwoDealt = 0;
     stats.conversions.forEach((conversion) => {
-      if (conversion.lastHitBy === mewTwo.playerIndex) {
+      if (conversion.playerIndex === mewTwo.playerIndex) {
         totalDamageMewTwoDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
       }
     });

--- a/test/stats.spec.ts
+++ b/test/stats.spec.ts
@@ -67,7 +67,7 @@ describe("when calculating stats", () => {
       const yl = stats.overall[1];
       let totalDamagePuffDealt = 0;
       stats.conversions.forEach((conversion) => {
-        if (conversion.lastHitBy === puff.playerIndex) {
+        if (conversion.playerIndex === puff.playerIndex) {
           totalDamagePuffDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
         }
       });
@@ -87,11 +87,15 @@ describe("when calculating stats", () => {
       let totalDamagePichuDealt = 0;
       let icsDamageDealt = 0;
       stats.conversions.forEach((conversion) => {
-        if (conversion.playerIndex === pichu.playerIndex) {
-          icsDamageDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
-        }
-        if (conversion.playerIndex === ics.playerIndex) {
-          totalDamagePichuDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
+        switch (conversion.playerIndex) {
+          case pichu.playerIndex: {
+            totalDamagePichuDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
+            break;
+          }
+          case ics.playerIndex: {
+            icsDamageDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
+            break;
+          }
         }
       });
       // Pichu should have done at least 32% damage
@@ -113,10 +117,10 @@ describe("when calculating stats", () => {
       let totalDamageNessDealt = 0;
       let totalDamageFoxDealt = 0;
       stats.conversions.forEach((conversion) => {
-        if (conversion.lastHitBy === ness.playerIndex) {
+        if (conversion.playerIndex === ness.playerIndex) {
           totalDamageNessDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
         }
-        if (conversion.lastHitBy === fox.playerIndex) {
+        if (conversion.playerIndex === fox.playerIndex) {
           totalDamageFoxDealt += conversion.moves.reduce((total, move) => total + move.damage, 0);
         }
       });


### PR DESCRIPTION
This reverts commit 3de9791b4d1bf5497f085da353366c65daf4d221.

The doubles statistics requires the `lastHitBy` value to be correct but under certain circumstances (presumable when a character is pummelling a grounded opponent) the `lastHitBy` value is incorrect (reports player ID 6). Until this is fixed, the statistics is going to be incorrect. So we revert the double stats for now.