### PR TITLE
Allow SlippiGame to accept an ArrayBuffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slippi/slippi-js",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Official Project Slippi Javascript SDK",
   "license": "LGPL-3.0-or-later",
   "repository": "project-slippi/slippi-js",

--- a/src/SlippiGame.ts
+++ b/src/SlippiGame.ts
@@ -32,7 +32,7 @@ export class SlippiGame {
   private inputComputer: InputComputer = new InputComputer();
   private statsComputer: Stats;
 
-  public constructor(input: string | Buffer, opts?: StatOptions) {
+  public constructor(input: string | Buffer | ArrayBuffer, opts?: StatOptions) {
     if (_.isString(input)) {
       this.input = {
         source: SlpInputSource.FILE,
@@ -42,6 +42,11 @@ export class SlippiGame {
       this.input = {
         source: SlpInputSource.BUFFER,
         buffer: input,
+      };
+    } else if (input instanceof ArrayBuffer) {
+      this.input = {
+        source: SlpInputSource.BUFFER,
+        buffer: Buffer.from(input),
       };
     } else {
       throw new Error("Cannot create SlippiGame with input of that type");

--- a/test/game.spec.ts
+++ b/test/game.spec.ts
@@ -119,6 +119,16 @@ it("should be able to support reading from a buffer input", () => {
   expect(_.last(settings.players).characterId).toBe(0xe);
 });
 
+it("should be able to support reading from an array buffer input", () => {
+  const buf = fs.readFileSync("slp/sheik_vs_ics_yoshis.slp");
+  const arrayBuf = buf.buffer;
+  const game = new SlippiGame(arrayBuf);
+  const settings = game.getSettings();
+  expect(settings.stageId).toBe(8);
+  expect(_.first(settings.players).characterId).toBe(0x13);
+  expect(_.last(settings.players).characterId).toBe(0xe);
+});
+
 it("should support realtime parsing", () => {
   const fullData = fs.readFileSync("slp/realtimeTest.slp");
   const buf = Buffer.alloc(100e6); // Allocate 100 MB of space


### PR DESCRIPTION
This makes it easier to use slippi-js in the browser via the Snowpack build tool, and probably for other build tools as well.

Snowpack can polyfill dependencies that need Node globals like Buffer by inlining them into the module of the dependency. That means slippi-js gets it's own Buffer library for internal use, but it's not possible for app code to create a Buffer object that will satisfy the instanceof check even if they use the same polyfill library. Passing in an ArrayBuffer will work on Node and in the browser.