### PR TITLE
Add ability to quickly read game winners

### DIFF
--- a/src/SlippiGame.ts
+++ b/src/SlippiGame.ts
@@ -22,8 +22,7 @@ import type {
 } from "./types";
 import { SlpParser, SlpParserEvent } from "./utils/slpParser";
 import type { SlpReadInput } from "./utils/slpReader";
-import { getGameEnd } from "./utils/slpReader";
-import { closeSlpFile, getMetadata, iterateEvents, openSlpFile, SlpInputSource } from "./utils/slpReader";
+import { closeSlpFile, getGameEnd, getMetadata, iterateEvents, openSlpFile, SlpInputSource } from "./utils/slpReader";
 
 /**
  * Slippi Game class that wraps a file
@@ -124,7 +123,11 @@ export class SlippiGame {
 
   public getGameEnd(options: { skipProcessing?: boolean } = {}): GameEndType | null {
     if (options?.skipProcessing) {
-      return getGameEnd(this.input);
+      // Read game end block directly
+      const slpfile = openSlpFile(this.input);
+      const gameEnd = getGameEnd(slpfile);
+      closeSlpFile(slpfile);
+      return gameEnd;
     }
 
     this._process();
@@ -210,7 +213,7 @@ export class SlippiGame {
   }
 
   public getWinners(): PlacementType[] {
-    const gameEnd = getGameEnd(this.input);
+    const gameEnd = this.getGameEnd({ skipProcessing: true });
     if (!gameEnd) {
       return [];
     }

--- a/src/SlippiGame.ts
+++ b/src/SlippiGame.ts
@@ -22,6 +22,7 @@ import type {
 } from "./types";
 import { SlpParser, SlpParserEvent } from "./utils/slpParser";
 import type { SlpReadInput } from "./utils/slpReader";
+import { getGameEnd } from "./utils/slpReader";
 import { closeSlpFile, getMetadata, iterateEvents, openSlpFile, SlpInputSource } from "./utils/slpReader";
 
 /**
@@ -205,9 +206,7 @@ export class SlippiGame {
   }
 
   public getWinners(): PlacementType[] {
-    this._process();
-
-    const gameEnd = this.getGameEnd();
+    const gameEnd = getGameEnd(this.input);
     if (!gameEnd) {
       return [];
     }

--- a/src/SlippiGame.ts
+++ b/src/SlippiGame.ts
@@ -122,7 +122,11 @@ export class SlippiGame {
     return this.parser.getLatestFrame();
   }
 
-  public getGameEnd(): GameEndType | null {
+  public getGameEnd(options: { skipProcessing?: boolean } = {}): GameEndType | null {
+    if (options?.skipProcessing) {
+      return getGameEnd(this.input);
+    }
+
     this._process();
     return this.parser.getGameEnd();
   }

--- a/src/utils/slpReader.ts
+++ b/src/utils/slpReader.ts
@@ -646,7 +646,7 @@ export function getMetadata(slpFile: SlpFileType): MetadataType | null {
 }
 
 export function getGameEnd(slpFile: SlpFileType): GameEndType | null {
-  const { rawDataPosition, rawDataLength, messageSizes } = slpFile;
+  const { ref, rawDataPosition, rawDataLength, messageSizes } = slpFile;
   const gameEndPayloadSize = messageSizes[Command.GAME_END];
   if (!exists(gameEndPayloadSize) || gameEndPayloadSize <= 0) {
     return null;
@@ -657,7 +657,7 @@ export function getGameEnd(slpFile: SlpFileType): GameEndType | null {
   const gameEndPosition = rawDataPosition + rawDataLength - gameEndSize;
 
   const buffer = new Uint8Array(gameEndSize);
-  readRef(slpFile.ref, buffer, 0, buffer.length, gameEndPosition);
+  readRef(ref, buffer, 0, buffer.length, gameEndPosition);
   if (buffer[0] !== Command.GAME_END) {
     // This isn't even a game end payload
     return null;

--- a/test/slpReader.spec.ts
+++ b/test/slpReader.spec.ts
@@ -1,0 +1,63 @@
+import _ from "lodash";
+
+import { SlippiGame } from "../src";
+import { getGameEnd, SlpInputSource } from "../src/utils/slpReader";
+
+describe("when reading game end directly", () => {
+  it("should return the same game end object", () => {
+    const game = new SlippiGame("slp/test.slp");
+    const gameEnd = game.getGameEnd()!;
+
+    const manualGameEnd = getManualGameEnd("slp/test.slp")!;
+    expect(gameEnd.gameEndMethod).toEqual(manualGameEnd.gameEndMethod);
+    expect(gameEnd.lrasInitiatorIndex).toEqual(manualGameEnd.lrasInitiatorIndex);
+    expect(gameEnd.placements.length).toEqual(manualGameEnd.placements.length);
+  });
+
+  it("should return the correct placings for 2 player games", () => {
+    const manualGameEnd = getManualGameEnd("slp/placementsTest/ffa_1p2p_winner_2p.slp")!;
+    const placements = manualGameEnd.placements!;
+    expect(placements).toHaveLength(4);
+    console.log(JSON.stringify(placements));
+    expect(placements[0].position).toBe(1); // player in port 1 is on second place
+    expect(placements[0].playerIndex).toBe(0);
+    expect(placements[1].position).toBe(0); // player in port 2 is on first place
+    expect(placements[1].playerIndex).toBe(1);
+  });
+
+  it("should return placings for 3 player games", () => {
+    let manualGameEnd = getManualGameEnd("slp/placementsTest/ffa_1p2p3p_winner_3p.slp")!;
+    let placements = manualGameEnd.placements!;
+    expect(placements).toBeDefined();
+    expect(placements).toHaveLength(4);
+
+    expect(placements[0].playerIndex).toBe(0);
+    expect(placements[1].playerIndex).toBe(1);
+    expect(placements[2].playerIndex).toBe(2);
+    expect(placements[3].playerIndex).toBe(3);
+
+    expect(placements[0].position).toBe(1); // Expect player 1 to be on second place
+    expect(placements[1].position).toBe(2); // Expect player 2 to be on third place
+    expect(placements[2].position).toBe(0); // Expect player 3 to be first place
+    expect(placements[3].position).toBe(-1); // Expect player 4 to not be present
+
+    manualGameEnd = getManualGameEnd("slp/placementsTest/ffa_1p2p4p_winner_4p.slp")!;
+    placements = manualGameEnd.placements!;
+    expect(placements).toBeDefined();
+    expect(placements).toHaveLength(4);
+
+    expect(placements[0].playerIndex).toBe(0);
+    expect(placements[1].playerIndex).toBe(1);
+    expect(placements[2].playerIndex).toBe(2);
+    expect(placements[3].playerIndex).toBe(3);
+
+    expect(placements[0].position).toBe(1); // Expect player 1 to be on second place
+    expect(placements[1].position).toBe(2); // Expect player 2 to be on third place
+    expect(placements[2].position).toBe(-1); // Expect player 3 to not be present
+    expect(placements[3].position).toBe(0); // Expect player 4 to be first place
+  });
+});
+
+function getManualGameEnd(filePath: string) {
+  return getGameEnd({ source: SlpInputSource.FILE, filePath });
+}

--- a/test/slpReader.spec.ts
+++ b/test/slpReader.spec.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 
 import { SlippiGame } from "../src";
-import { getGameEnd, SlpInputSource } from "../src/utils/slpReader";
+import { closeSlpFile, getGameEnd, openSlpFile, SlpInputSource } from "../src/utils/slpReader";
 
 describe("when reading game end directly", () => {
   it("should return the same game end object", () => {
@@ -59,5 +59,8 @@ describe("when reading game end directly", () => {
 });
 
 function getManualGameEnd(filePath: string) {
-  return getGameEnd({ source: SlpInputSource.FILE, filePath });
+  const slpfile = openSlpFile({ source: SlpInputSource.FILE, filePath });
+  const gameEnd = getGameEnd(slpfile);
+  closeSlpFile(slpfile);
+  return gameEnd;
 }


### PR DESCRIPTION
This PR adds a way to quickly read the game end block and the game winners without reading through the entire file. We do this so we can quickly access and display the winner in Slippi Launcher.