### PR TITLE
Improved Conversion Logic

### DIFF
--- a/src/stats/combos.ts
+++ b/src/stats/combos.ts
@@ -7,6 +7,9 @@ import {
   calcDamageTaken,
   didLoseStock,
   getSinglesPlayerPermutationsFromSettings,
+  isOffstage,
+  isDodging,
+  isShielding,
   isCommandGrabbed,
   isDamaged,
   isDead,
@@ -187,14 +190,19 @@ function handleComboCompute(
   const opntIsDowned = isDown(oppActionStateId);
   const opntDidLoseStock = prevOpponentFrame && didLoseStock(opponentFrame, prevOpponentFrame);
   const opntIsDying = isDead(oppActionStateId);
+  const opntPosition = [opponentFrame.positionX, opponentFrame.positionY]
+  const opntIsOffstage = isOffstage(opntPosition, settings.stageId);
+  const opntIsDodging = isDodging(oppActionStateId);
+  const opntIsShielding = isShielding(oppActionStateId);
 
   // Update percent if opponent didn't lose stock
   if (!opntDidLoseStock) {
     state.combo.currentPercent = opponentFrame.percent ?? 0;
   }
 
-  if (opntIsDamaged || opntIsGrabbed || opntIsCommandGrabbed || opntIsTeching || opntIsDowned || opntIsDying) {
+  if (opntIsDamaged || opntIsGrabbed || opntIsCommandGrabbed || opntIsTeching || opntIsDowned || opntIsDying || opntIsOffstage || opntIsDodging || isShielding) {
     // If opponent got grabbed or damaged, reset the reset counter
+    //Additionally, reset if opponent is offstage, in shield, or rolling/spot dodging/air dodging
     state.resetCounter = 0;
   } else {
     state.resetCounter += 1;

--- a/src/stats/combos.ts
+++ b/src/stats/combos.ts
@@ -7,9 +7,6 @@ import {
   calcDamageTaken,
   didLoseStock,
   getSinglesPlayerPermutationsFromSettings,
-  isOffstage,
-  isDodging,
-  isShielding,
   isCommandGrabbed,
   isDamaged,
   isDead,
@@ -190,19 +187,14 @@ function handleComboCompute(
   const opntIsDowned = isDown(oppActionStateId);
   const opntDidLoseStock = prevOpponentFrame && didLoseStock(opponentFrame, prevOpponentFrame);
   const opntIsDying = isDead(oppActionStateId);
-  const opntPosition = [opponentFrame.positionX, opponentFrame.positionY]
-  const opntIsOffstage = isOffstage(opntPosition, settings.stageId);
-  const opntIsDodging = isDodging(oppActionStateId);
-  const opntIsShielding = isShielding(oppActionStateId);
 
   // Update percent if opponent didn't lose stock
   if (!opntDidLoseStock) {
     state.combo.currentPercent = opponentFrame.percent ?? 0;
   }
 
-  if (opntIsDamaged || opntIsGrabbed || opntIsCommandGrabbed || opntIsTeching || opntIsDowned || opntIsDying || opntIsOffstage || opntIsDodging || isShielding) {
+  if (opntIsDamaged || opntIsGrabbed || opntIsCommandGrabbed || opntIsTeching || opntIsDowned || opntIsDying) {
     // If opponent got grabbed or damaged, reset the reset counter
-    //Additionally, reset if opponent is offstage, in shield, or rolling/spot dodging/air dodging
     state.resetCounter = 0;
   } else {
     state.resetCounter += 1;

--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -321,8 +321,8 @@ export function isCommandGrabbed(state: number): boolean {
   );
 }
 
-export function isOffstage(position: Array<number | null>, currStage: number | null): boolean {
-  if (position == null || currStage == null) {
+export function isOffstage(position: Array<number | null>, currStage?: number | null): boolean {
+  if (!position || !currStage) {
     return false;
   }
 

--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -185,6 +185,10 @@ export enum State {
   ATTACK_FTILT_END = 0x37,
   ATTACK_FSMASH_START = 0x3a,
   ATTACK_FSMASH_END = 0x3e,
+  GUARD_BREAK_START = 0xcd,
+  GUARD_BREAK_END = 0xd3,
+  DODGE_START = 0xe9,
+  DODGE_END = 0xec,
 
   // Animation ID specific
   ROLL_FORWARD = 0xe9,
@@ -349,7 +353,7 @@ export function isOffstage(position:Array, currStage: number): boolean {
       return false;
   }
 
-  if(position[0] > stageBounds[0] && position[0] < stageBounds[1]){
+  if(position[0] < stageBounds[0] && position[0] > stageBounds[1]){
     return true;
   }
   else return false;
@@ -357,7 +361,7 @@ export function isOffstage(position:Array, currStage: number): boolean {
 }
 
 export function isDodging(state:number):boolean { //not the greatest term, but captures rolling, spot dodging, and air dodging
-  return state == State.ROLL_FORWARD || state == State.ROLL_BACKWARD || state == State.AIR_DODGE || state == State.SPOT_DODGE;
+  return state >= State.DODGE_START && state <= State.DODGE_END;
 }
 
 export function isShielding(state:number):boolean {
@@ -373,4 +377,8 @@ export function calcDamageTaken(frame: PostFrameUpdateType, prevFrame: PostFrame
   const prevPercent = prevFrame.percent ?? 0;
 
   return percent - prevPercent;
+}
+
+export function isShieldBroken(state:number):boolean{
+  return state >= State.GUARD_BREAK_START && state <= State.GUARD_BREAK_END;
 }

--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -1,4 +1,5 @@
-import type { GameStartType, PostFrameUpdateType } from "../types";
+import type { GameStartType, PostFrameUpdateType, FrameType } from "../types";
+import Stage from "../melee/types.ts";
 
 export interface StatsType {
   gameComplete: boolean;
@@ -321,6 +322,46 @@ export function isCommandGrabbed(state: number): boolean {
       (state >= State.COMMAND_GRAB_RANGE2_START && state <= State.COMMAND_GRAB_RANGE2_END)) &&
     state !== State.BARREL_WAIT
   );
+}
+
+export function isOffstage(position:Array, currStage: number): boolean {
+  let stageBounds = [0, 0]
+  switch(currStage.name){
+    case Stage.FOUNTAIN_OF_DREAMS:
+      stageBounds = [-64, 64]
+      break;
+    case Stage.YOSHIS_STORY:
+      stageBounds = [-56, 56]
+      break;
+    case Stage.DREAMLAND:
+      stageBounds = [-73, 73]
+      break;
+    case Stage.POKEMON_STADIUM:
+      stageBounds = [-88, 88]
+      break;
+    case Stage.BATTLEFIELD:
+      stageBounds = [-67, 67]
+      break;
+    case Stage.FINAL_DESTINATION:
+      stageBounds = [-89, 89]
+      break;
+    default:
+      return false;
+  }
+
+  if(position[0] > stageBounds[0] && position[0] < stageBounds[1]){
+    return true;
+  }
+  else return false;
+
+}
+
+export function isDodging(state:number):boolean { //not the greatest term, but captures rolling, spot dodging, and air dodging
+  return state == State.ROLL_FORWARD || state == State.ROLL_BACKWARD || state == State.AIR_DODGE || state == State.SPOT_DODGE;
+}
+
+export function isShielding(state:number):boolean {
+  return state >= State.GUARD_START && state <= State.GUARD_END;
 }
 
 export function isDead(state: number): boolean {

--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -1,5 +1,5 @@
-import type { GameStartType, PostFrameUpdateType, FrameType } from "../types";
-import Stage from "../melee/types.ts";
+import type { GameStartType, PostFrameUpdateType } from "../types";
+import { Stage } from "../melee/types";
 
 export interface StatsType {
   gameComplete: boolean;
@@ -175,6 +175,8 @@ export enum State {
   TECH_END = 0xcc,
   DYING_START = 0x0,
   DYING_END = 0xa,
+  LEDGE_ACTION_START = 0xfc,
+  LEDGE_ACTION_END = 0x107,
   CONTROLLED_JUMP_START = 0x18,
   CONTROLLED_JUMP_END = 0x22,
   GROUND_ATTACK_START = 0x2c,
@@ -294,15 +296,6 @@ export function didLoseStock(frame: PostFrameUpdateType, prevFrame: PostFrameUpd
   return prevFrame.stocksRemaining! - frame.stocksRemaining! > 0;
 }
 
-export function isInControl(state: number): boolean {
-  const ground = state >= State.GROUNDED_CONTROL_START && state <= State.GROUNDED_CONTROL_END;
-  const squat = state >= State.SQUAT_START && state <= State.SQUAT_END;
-  const groundAttack = state > State.GROUND_ATTACK_START && state <= State.GROUND_ATTACK_END;
-  const isGrab = state === State.GRAB;
-  // TODO: Add grounded b moves?
-  return ground || squat || groundAttack || isGrab;
-}
-
 export function isTeching(state: number): boolean {
   return state >= State.TECH_START && state <= State.TECH_END;
 }
@@ -328,43 +321,43 @@ export function isCommandGrabbed(state: number): boolean {
   );
 }
 
-export function isOffstage(position:Array, currStage: number): boolean {
-  let stageBounds = [0, 0]
-  switch(currStage.name){
+export function isOffstage(position: Array<number | null>, currStage: number | null): boolean {
+  if (position == null || currStage == null) {
+    return false;
+  }
+
+  let stageBounds = [0, 0];
+  switch (currStage) {
     case Stage.FOUNTAIN_OF_DREAMS:
-      stageBounds = [-64, 64]
+      stageBounds = [-64, 64];
       break;
     case Stage.YOSHIS_STORY:
-      stageBounds = [-56, 56]
+      stageBounds = [-56, 56];
       break;
     case Stage.DREAMLAND:
-      stageBounds = [-73, 73]
+      stageBounds = [-73, 73];
       break;
     case Stage.POKEMON_STADIUM:
-      stageBounds = [-88, 88]
+      stageBounds = [-88, 88];
       break;
     case Stage.BATTLEFIELD:
-      stageBounds = [-67, 67]
+      stageBounds = [-67, 67];
       break;
     case Stage.FINAL_DESTINATION:
-      stageBounds = [-89, 89]
+      stageBounds = [-89, 89];
       break;
     default:
       return false;
   }
-
-  if(position[0] < stageBounds[0] && position[0] > stageBounds[1]){
-    return true;
-  }
-  else return false;
-
+  return position[0]! < stageBounds[0]! && position[0]! > stageBounds[1]!;
 }
 
-export function isDodging(state:number):boolean { //not the greatest term, but captures rolling, spot dodging, and air dodging
+export function isDodging(state: number): boolean {
+  //not the greatest term, but captures rolling, spot dodging, and air dodging
   return state >= State.DODGE_START && state <= State.DODGE_END;
 }
 
-export function isShielding(state:number):boolean {
+export function isShielding(state: number): boolean {
   return state >= State.GUARD_START && state <= State.GUARD_END;
 }
 
@@ -372,13 +365,17 @@ export function isDead(state: number): boolean {
   return state >= State.DYING_START && state <= State.DYING_END;
 }
 
+export function isShieldBroken(state: number): boolean {
+  return state >= State.GUARD_BREAK_START && state <= State.GUARD_BREAK_END;
+}
+
+export function isLedgeAction(state: number): boolean {
+  return state >= State.LEDGE_ACTION_START && state <= State.LEDGE_ACTION_END;
+}
+
 export function calcDamageTaken(frame: PostFrameUpdateType, prevFrame: PostFrameUpdateType): number {
   const percent = frame.percent ?? 0;
   const prevPercent = prevFrame.percent ?? 0;
 
   return percent - prevPercent;
-}
-
-export function isShieldBroken(state:number):boolean{
-  return state >= State.GUARD_BREAK_START && state <= State.GUARD_BREAK_END;
 }

--- a/src/stats/conversions.ts
+++ b/src/stats/conversions.ts
@@ -225,6 +225,8 @@ function handleConversionCompute(
   }
 
   const opntDidLoseStock = prevOpponentFrame && didLoseStock(opponentFrame, prevOpponentFrame);
+  const playerDidLoseStock = prevPlayerFrame && didLoseStock(playerFrame, prevPlayerFrame);
+
   const opntPosition = [opponentFrame.positionX, opponentFrame.positionY];
   const opntIsOffstage = isOffstage(opntPosition, stageId);
   const opntIsDodging = isDodging(oppActionStateId);
@@ -261,8 +263,8 @@ function handleConversionCompute(
 
   let shouldTerminate = false;
 
-  // Termination condition 1 - player kills opponent
-  if (opntDidLoseStock) {
+  // Termination condition 1 - player kills opponent or opponent kills player
+  if (opntDidLoseStock || playerDidLoseStock) {
     state.conversion.didKill = true;
     shouldTerminate = true;
   }

--- a/src/stats/conversions.ts
+++ b/src/stats/conversions.ts
@@ -74,7 +74,14 @@ export class ConversionComputer extends EventEmitter implements StatComputer<Con
     this.playerPermutations.forEach((indices) => {
       const state = this.state.get(indices);
       if (state) {
-        const terminated = handleConversionCompute(allFrames, state, indices, frame, this.conversions, this.settings);
+        const terminated = handleConversionCompute(
+          allFrames,
+          state,
+          indices,
+          frame,
+          this.conversions,
+          this.settings?.stageId,
+        );
         if (terminated) {
           this.emit("CONVERSION", {
             combo: last(this.conversions),
@@ -130,7 +137,7 @@ function handleConversionCompute(
   indices: PlayerIndexedType,
   frame: FrameEntryType,
   conversions: ConversionType[],
-  settings: GameStartType | null,
+  stageId: number | null | undefined,
 ): boolean {
   const currentFrameNumber = frame.frame;
   const playerFrame: PostFrameUpdateType = frame.players[indices.playerIndex]!.post;
@@ -219,7 +226,7 @@ function handleConversionCompute(
 
   const opntDidLoseStock = prevOpponentFrame && didLoseStock(opponentFrame, prevOpponentFrame);
   const opntPosition = [opponentFrame.positionX, opponentFrame.positionY];
-  const opntIsOffstage = isOffstage(opntPosition, settings!.stageId);
+  const opntIsOffstage = isOffstage(opntPosition, stageId);
   const opntIsDodging = isDodging(oppActionStateId);
   const opntIsShielding = isShielding(oppActionStateId);
   const opntIsTeching = isTeching(oppActionStateId);

--- a/src/stats/conversions.ts
+++ b/src/stats/conversions.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "events";
 import { filter, get, groupBy, last, orderBy } from "lodash";
 
 import type { FrameEntryType, FramesType, GameStartType, PostFrameUpdateType } from "../types";
-import { ConversionType, MoveLandedType, PlayerIndexedType } from "./common";
+import type { ConversionType, MoveLandedType, PlayerIndexedType } from "./common";
 import {
   calcDamageTaken,
   didLoseStock,


### PR DESCRIPTION
As a warning, I don't really know JS/TS so some of the formatting/type hints/non null assertions might be wrong. 

Basically, conversion timer reset logic is based off of checking for a handful of actionable states that indicate that someone has escaped a combo. That check, per its comment, isn't complete. As a result there's a lot of weird edge cases and "false positives" that let conversions go on when they shouldn't. Additionally, with the weird way that the reset counter was set up, conversions would end before they should in some instances (e.g. mid-combo shield pressure that lasts more than 45 frames, shield breaks with long startup moves, etc.). 

It's WAY easier to check for the usual non-actionable states than the actionable ones. I've been using this modified logic (in addition to checking the player bitfields for hitstun and hitlag) in my fork of the py-slippi parser and it's been working quite well.

I added in helper functions in the same format as the existing ones, and then added those checks to the conversion calculator, and matched the reset functionality to the one in combo.ts. One of the checks requires checking the stage, so that value is now passed to handleConversionCompute. Additional checks could be added to refine the "offstage" x value check (check Y to make sure they're not underneath battlefield, or to see if they're high enough that they're likely being juggled), but those situations are niche, require some fine-tuning, and come with some false positives, so I've left them out for now. It also might be worth adding the jigg's sing sleep state and jigg's rest state but I wasn't 100% sure what the IDs for those were.