### PR TITLE
Parse instance id info

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,8 @@ export type PostFrameUpdateType = {
   selfInducedSpeeds: SelfInducedSpeedsType | null;
   hitlagRemaining: number | null;
   animationIndex: number | null;
+  instanceHitBy: number | null;
+  instanceId: number | null;
 };
 
 export type SelfInducedSpeedsType = {
@@ -233,6 +235,7 @@ export type ItemUpdateType = {
   chargeShotLaunched: number | null;
   chargePower: number | null;
   owner: number | null;
+  instanceId: number | null;
 };
 
 export type FrameBookendType = {

--- a/src/utils/slpReader.ts
+++ b/src/utils/slpReader.ts
@@ -512,6 +512,8 @@ export function parseMessage(command: Command, payload: Uint8Array): EventPayloa
         selfInducedSpeeds: selfInducedSpeeds,
         hitlagRemaining: readFloat(view, 0x49),
         animationIndex: readUint32(view, 0x4d),
+        instanceHitBy: readUint16(view, 0x51),
+        instanceId: readUint16(view, 0x53),
       };
     case Command.ITEM_UPDATE:
       return {
@@ -531,6 +533,7 @@ export function parseMessage(command: Command, payload: Uint8Array): EventPayloa
         chargeShotLaunched: readUint8(view, 0x28),
         chargePower: readUint8(view, 0x29),
         owner: readInt8(view, 0x2a),
+        instanceId: readUint16(view, 0x2b),
       };
     case Command.FRAME_BOOKEND:
       return {


### PR DESCRIPTION
This PR is intended to parse instance id data added by https://github.com/project-slippi/slippi-ssbm-asm/pull/120

Here is what a ~10 second match against a CPU looks like when you print all the post-frame/item updates and their relevant instance id info:

https://pastebin.com/5zP8MdgB

As mentioned in the other PR these fields can be used to better track hits in doubles because lastHitBy field is unreliable (https://github.com/project-slippi/slippi-js/pull/71).