### PR TITLE
Fixed jab reset detection in combos

### DIFF
--- a/src/SlippiGame.ts
+++ b/src/SlippiGame.ts
@@ -22,19 +22,19 @@ import type {
   PostFrameUpdateType,
   RollbackFrames,
 } from "./types";
-import { GameMode, GameEndMethod } from "./types";
+import { GameEndMethod, GameMode } from "./types";
 import { getWinners } from "./utils/getWinners";
 import { extractDistanceInfoFromFrame } from "./utils/homeRunDistance";
 import { SlpParser, SlpParserEvent } from "./utils/slpParser";
 import type { SlpFileType, SlpReadInput } from "./utils/slpReader";
 import {
   closeSlpFile,
+  extractFinalPostFrameUpdates,
   getGameEnd,
   getMetadata,
   iterateEvents,
   openSlpFile,
   SlpInputSource,
-  extractFinalPostFrameUpdates,
 } from "./utils/slpReader";
 
 /**

--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -312,7 +312,7 @@ export function isDamaged(state: number): boolean {
   return ((state >= State.DAMAGE_START && state <= State.DAMAGE_END) ||
     state === State.DAMAGE_FALL ||
     state === State.JAB_RESET_UP ||
-    state == State.JAB_RESET_DOWN);
+    state === State.JAB_RESET_DOWN);
 }
 
 export function isGrabbed(state: number): boolean {

--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -309,10 +309,12 @@ export function isDown(state: number): boolean {
 }
 
 export function isDamaged(state: number): boolean {
-  return ((state >= State.DAMAGE_START && state <= State.DAMAGE_END) ||
+  return (
+    (state >= State.DAMAGE_START && state <= State.DAMAGE_END) ||
     state === State.DAMAGE_FALL ||
     state === State.JAB_RESET_UP ||
-    state === State.JAB_RESET_DOWN);
+    state === State.JAB_RESET_DOWN
+  );
 }
 
 export function isGrabbed(state: number): boolean {

--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -195,7 +195,9 @@ export enum State {
   ACTION_KNEE_BEND = 0x18,
   GUARD_ON = 0xb2,
   TECH_MISS_UP = 0xb7,
+  JAB_RESET_UP = 0xb9,
   TECH_MISS_DOWN = 0xbf,
+  JAB_RESET_DOWN = 0xc1,
   NEUTRAL_TECH = 0xc7,
   FORWARD_TECH = 0xc8,
   BACKWARD_TECH = 0xc9,
@@ -307,7 +309,10 @@ export function isDown(state: number): boolean {
 }
 
 export function isDamaged(state: number): boolean {
-  return (state >= State.DAMAGE_START && state <= State.DAMAGE_END) || state === State.DAMAGE_FALL;
+  return ((state >= State.DAMAGE_START && state <= State.DAMAGE_END) ||
+    state === State.DAMAGE_FALL ||
+    state === State.JAB_RESET_UP ||
+    state == State.JAB_RESET_DOWN);
 }
 
 export function isGrabbed(state: number): boolean {


### PR DESCRIPTION
As noted by Lunar Melee, jab resets aren't picked up by the combo/conversion computers. There's also some false-detection around mangifying-glass damage.

Jab reset states added to isDamaged should take care of the former, the latter is finnicky.

An alternative solution that would fix both would be to check the hitstun (or defender hitlag) bitflag. Doing so would require replays of at least version 2.0.0, so I've held off for now in case I think of something with better compatibility.