### PR TITLE
Fixed conversion detection for mario/doc's Cape

### DIFF
--- a/src/stats/conversions.ts
+++ b/src/stats/conversions.ts
@@ -161,9 +161,11 @@ function handleConversionCompute(
     state.lastHitAnimation = null;
   }
 
+  const lastAttackChanged = prevPlayerFrame?.lastAttackLanded != playerFrame.lastAttackLanded;
+
   // If opponent took damage and was put in some kind of stun this frame, either
   // start a conversion or
-  if (opntIsDamaged || opntIsGrabbed || opntIsCommandGrabbed) {
+  if (opntIsDamaged || opntIsGrabbed || opntIsCommandGrabbed || lastAttackChanged || opntDamageTaken > 3.1) {
     if (!state.conversion) {
       state.conversion = {
         playerIndex: indices.opponentIndex,

--- a/src/stats/conversions.ts
+++ b/src/stats/conversions.ts
@@ -161,7 +161,7 @@ function handleConversionCompute(
     state.lastHitAnimation = null;
   }
 
-  const lastAttackChanged = prevPlayerFrame?.lastAttackLanded != playerFrame.lastAttackLanded;
+  const lastAttackChanged = prevPlayerFrame ? prevPlayerFrame.lastAttackLanded != playerFrame.lastAttackLanded : false;
 
   // If opponent took damage and was put in some kind of stun this frame, either
   // start a conversion or

--- a/src/stats/conversions.ts
+++ b/src/stats/conversions.ts
@@ -223,7 +223,7 @@ function handleConversionCompute(
     state.conversion.currentPercent = opponentFrame.percent ?? 0;
   }
 
-  if (opntIsDamaged || opntIsGrabbed || opntIsCommandGrabbed) {
+  if (opntIsDamaged || opntIsGrabbed || opntIsCommandGrabbed || lastAttackChanged || opntDamageTaken > 3.1) {
     // If opponent got grabbed or damaged, reset the reset counter
     state.resetCounter = 0;
   }


### PR DESCRIPTION
An individual on r/ssbm [pointed out that](https://old.reddit.com/r/SSBM/comments/15xyx3r/daily_discussion_thread_aug_22_2023_upcoming/jxa28c8/) cape is not detected at all for conversion and combo detection. This is due to cape not changing a character's action state on hit. A hitlag check would pick it up, but to maintain 0.2.0 compatibility i try to avoid that. Here are the checks i used:

* `lastAttackLanded` changing from previous to current frame

This should not only cover cape, but also some weird edge cases like fox's laser and phantom hits. The flaw of this is that if 2 of them happen in a row, last attack landed won't change so it'll be missed. That's pretty rare though, so the next check isn't 100% necessary if it turns out to be too far

* opponent takes more than 3.1% damage

Fully staled minimum damage cape does 3.15%. 3.1% is high enough that it won't trigger on magnifying glass or any form of pichu's self damage (which maxes out at 3%). The only other self damage i can think of that doesn't trigger any of the `isDamaged` states would be roy's fully charged neutral B

Alternatively, a more targeted check could work. Cape doesn't change the recipient's state, but it does incur hitlag and pause the action state counter. Checking for a change in the action state counter would also resolve the [magnifying glass](https://discord.com/channels/328261477372919811/755937214038540368/1085292039110938846) bug. As a side note, cape doesn't turn you around instantly, so you can't use `facingDirection` to detect it unfortunately =(

This isn't super well tested though, mainly because i have very few mario/doc replays laying around, and even fewer for most low tiers whose edge cases i'm probably forgetting. If y'all have some laying around, i'd be very grateful if you shot them my way. If not, i'll do my best to source a few hundred so i can test it fully before finalizing.