### PR TITLE
Refactor typings to reduce/remove type casts

### DIFF
--- a/src/console/communication.ts
+++ b/src/console/communication.ts
@@ -6,7 +6,7 @@ export enum CommunicationType {
   KEEP_ALIVE = 3,
 }
 
-export interface CommunicationMessage {
+export type CommunicationMessage = {
   type: CommunicationType;
   payload: {
     cursor: Uint8Array;
@@ -18,7 +18,7 @@ export interface CommunicationMessage {
     forcePos: boolean;
     nintendontVersion: string | null;
   };
-}
+};
 
 // This class is responsible for handling the communication protocol between the Wii and the
 // desktop app

--- a/src/console/types.ts
+++ b/src/console/types.ts
@@ -22,17 +22,17 @@ export enum Ports {
   RELAY_START = 53741,
 }
 
-export interface ConnectionDetails {
+export type ConnectionDetails = {
   consoleNick: string;
   gameDataCursor: number | Uint8Array;
   version: string;
   clientToken?: number;
-}
+};
 
-export interface ConnectionSettings {
+export type ConnectionSettings = {
   ipAddress: string;
   port: number;
-}
+};
 
 export interface Connection extends EventEmitter {
   getStatus(): ConnectionStatus;

--- a/src/melee/characterUtils.ts
+++ b/src/melee/characterUtils.ts
@@ -3,12 +3,12 @@ import characters from "./characters.json";
 export type CharacterColor = string;
 const DEFAULT_COLOR: CharacterColor = "Default";
 
-export interface CharacterInfo {
+export type CharacterInfo = {
   id: number;
   name: string;
   shortName: string;
   colors: CharacterColor[];
-}
+};
 
 export const UnknownCharacter: CharacterInfo = {
   id: -1,

--- a/src/melee/moveUtils.ts
+++ b/src/melee/moveUtils.ts
@@ -1,10 +1,10 @@
 import moveNames from "./moves.json";
 
-export interface Move {
+export type Move = {
   id: number;
   name: string;
   shortName: string;
-}
+};
 
 export const UnknownMove: Move = {
   id: -1,

--- a/src/melee/stageUtils.ts
+++ b/src/melee/stageUtils.ts
@@ -1,9 +1,9 @@
 import stageNames from "./stages.json";
 
-export interface StageInfo {
+export type StageInfo = {
   id: number;
   name: string;
-}
+};
 
 export const UnknownStage: StageInfo = {
   id: -1,

--- a/src/stats/actions.ts
+++ b/src/stats/actions.ts
@@ -13,11 +13,11 @@ import type { StatComputer } from "./stats";
 // Frame pattern that indicates a dash dance turn was executed
 const dashDanceAnimations = [State.DASH, State.TURN, State.DASH];
 
-interface PlayerActionState {
+type PlayerActionState = {
   playerCounts: ActionCountsType;
   animations: number[];
   actionFrameCounters: number[];
-}
+};
 
 export class ActionsComputer implements StatComputer<ActionCountsType[]> {
   private playerPermutations = new Array<PlayerIndexedType>();

--- a/src/stats/combos.ts
+++ b/src/stats/combos.ts
@@ -23,13 +23,13 @@ export enum ComboEvent {
   COMBO_END = "COMBO_END",
 }
 
-interface ComboState {
+type ComboState = {
   combo: ComboType | null;
   move: MoveLandedType | null;
   resetCounter: number;
   lastHitAnimation: number | null;
   event: ComboEvent | null;
-}
+};
 
 export class ComboComputer extends EventEmitter implements StatComputer<ComboType[]> {
   private playerPermutations = new Array<PlayerIndexedType>();

--- a/src/stats/common.ts
+++ b/src/stats/common.ts
@@ -1,6 +1,6 @@
 import type { GameStartType, PostFrameUpdateType } from "../types";
 
-export interface StatsType {
+export type StatsType = {
   gameComplete: boolean;
   lastFrame: number;
   playableFrameCount: number;
@@ -9,76 +9,78 @@ export interface StatsType {
   combos: ComboType[];
   actionCounts: ActionCountsType[];
   overall: OverallType[];
-}
+};
 
 export type StadiumStatsType = HomeRunContestResultType | TargetTestResultType;
 
-export interface TargetTestResultType {
+export type TargetTestResultType = {
   type: "target-test";
   targetBreaks: TargetBreakType[];
-}
+};
 
-export interface HomeRunContestResultType {
+export type HomeRunContestResultType = {
   type: "home-run-contest";
   distance: number;
   units: "feet" | "meters";
-}
+};
 
-export interface RatioType {
+export type RatioType = {
   count: number;
   total: number;
   ratio: number | null;
-}
+};
 
-export interface PlayerIndexedType {
+export type PlayerIndexedType = {
   playerIndex: number;
   opponentIndex: number;
-}
+};
 
-export interface DurationType {
+export type DurationType = {
   startFrame: number;
   endFrame?: number | null;
-}
+};
 
-export interface DamageType {
+export type DamageType = {
   startPercent: number;
   currentPercent: number;
   endPercent?: number | null;
-}
+};
 
-export interface StockType extends DurationType, DamageType {
-  playerIndex: number;
-  count: number;
-  deathAnimation?: number | null;
-}
+export type StockType = DurationType &
+  DamageType & {
+    playerIndex: number;
+    count: number;
+    deathAnimation?: number | null;
+  };
 
-export interface MoveLandedType {
+export type MoveLandedType = {
   playerIndex: number;
   frame: number;
   moveId: number;
   hitCount: number;
   damage: number;
-}
+};
 
-export interface ComboType extends DurationType, DamageType {
-  playerIndex: number;
-  moves: MoveLandedType[];
-  didKill: boolean;
-  lastHitBy: number | null;
-}
+export type ComboType = DurationType &
+  DamageType & {
+    playerIndex: number;
+    moves: MoveLandedType[];
+    didKill: boolean;
+    lastHitBy: number | null;
+  };
 
-export interface TargetBreakType {
+export type TargetBreakType = {
   spawnId: number;
   frameDestroyed: number | null;
   positionX: number;
   positionY: number;
-}
+};
 
-export interface ConversionType extends ComboType {
+export type ConversionType = ComboType & {
   openingType: string;
-}
+};
 
-export interface ActionCountsType {
+export type ActionCountsType = {
   playerIndex: number;
   wavedashCount: number;
   wavelandCount: number;
@@ -130,17 +132,17 @@ export interface ActionCountsType {
     success: number;
     fail: number;
   };
-}
+};
 
-export interface InputCountsType {
+export type InputCountsType = {
   buttons: number;
   triggers: number;
   joystick: number;
   cstick: number;
   total: number;
-}
+};
 
-export interface OverallType {
+export type OverallType = {
   playerIndex: number;
   inputCounts: InputCountsType;
   conversionCount: number;
@@ -154,7 +156,7 @@ export interface OverallType {
   neutralWinRatio: RatioType;
   counterHitRatio: RatioType;
   beneficialTradeRatio: RatioType;
-}
+};
 
 export enum State {
   // Animation ID ranges

--- a/src/stats/conversions.ts
+++ b/src/stats/conversions.ts
@@ -19,18 +19,18 @@ import {
 } from "./common";
 import type { StatComputer } from "./stats";
 
-interface PlayerConversionState {
+type PlayerConversionState = {
   conversion: ConversionType | null;
   move: MoveLandedType | null;
   resetCounter: number;
   lastHitAnimation: number | null;
-}
+};
 
-interface MetadataType {
+type MetadataType = {
   lastEndFrameByOppIdx: {
     [oppIdx: number]: number;
   };
-}
+};
 
 export class ConversionComputer extends EventEmitter implements StatComputer<ConversionType[]> {
   private playerPermutations = new Array<PlayerIndexedType>();

--- a/src/stats/inputs.ts
+++ b/src/stats/inputs.ts
@@ -16,7 +16,7 @@ enum JoystickRegion {
   W = 8,
 }
 
-export interface PlayerInput {
+export type PlayerInput = {
   playerIndex: number;
   opponentIndex: number;
   inputCount: number;
@@ -24,7 +24,7 @@ export interface PlayerInput {
   cstickInputCount: number;
   buttonInputCount: number;
   triggerInputCount: number;
-}
+};
 
 export class InputComputer implements StatComputer<PlayerInput[]> {
   private state = new Map<PlayerIndexedType, PlayerInput>();

--- a/src/stats/overall.ts
+++ b/src/stats/overall.ts
@@ -11,11 +11,11 @@ import type { GameStartType } from "../types";
 import type { ConversionType, InputCountsType, OverallType, RatioType } from "./common";
 import type { PlayerInput } from "./inputs";
 
-interface ConversionsByPlayerByOpening {
+type ConversionsByPlayerByOpening = {
   [playerIndex: string]: {
     [openingType: string]: ConversionType[];
   };
-}
+};
 
 export function generateOverallStats({
   settings,

--- a/src/stats/stats.ts
+++ b/src/stats/stats.ts
@@ -9,9 +9,9 @@ export interface StatComputer<T> {
   fetch(): T;
 }
 
-export interface StatOptions {
+export type StatOptions = {
   processOnTheFly: boolean;
-}
+};
 
 const defaultOptions: StatOptions = {
   processOnTheFly: false,

--- a/src/stats/stocks.ts
+++ b/src/stats/stocks.ts
@@ -3,9 +3,9 @@ import type { PlayerIndexedType, StockType } from "./common";
 import { didLoseStock, getSinglesPlayerPermutationsFromSettings, isDead } from "./common";
 import type { StatComputer } from "./stats";
 
-interface StockState {
+type StockState = {
   stock?: StockType | null;
-}
+};
 
 export class StockComputer implements StatComputer<StockType[]> {
   private state = new Map<PlayerIndexedType, StockState>();

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export enum Command {
   GECKO_LIST = 0x3d,
 }
 
-export interface PlayerType {
+export type PlayerType = {
   playerIndex: number;
   port: number;
   characterId: number | null;
@@ -38,7 +38,7 @@ export interface PlayerType {
   displayName: string;
   connectCode: string;
   userId: string;
-}
+};
 
 export enum GameMode {
   VS = 0x02,
@@ -52,7 +52,7 @@ export enum Language {
   ENGLISH = 1,
 }
 
-export interface GameStartType {
+export type GameStartType = {
   slpVersion: string | null;
   timerType: TimerType | null;
   inGameMode: number | null;
@@ -71,21 +71,21 @@ export interface GameStartType {
   isPAL: boolean | null;
   isFrozenPS: boolean | null;
   matchInfo: MatchInfo | null;
-}
+};
 
-interface MatchInfo {
+type MatchInfo = {
   matchId: string | null;
   gameNumber: number | null;
   tiebreakerNumber: number | null;
-}
+};
 
-export interface FrameStartType {
+export type FrameStartType = {
   frame: number | null;
   seed: number | null;
   sceneFrameCounter: number | null;
-}
+};
 
-export interface GameInfoType {
+export type GameInfoType = {
   gameBitfield1: number | null;
   gameBitfield2: number | null;
   gameBitfield3: number | null;
@@ -98,7 +98,7 @@ export interface GameInfoType {
   itemSpawnBitfield4: number | null;
   itemSpawnBitfield5: number | null;
   damageRatio: number | null;
-}
+};
 
 export enum TimerType {
   NONE = 0b00,
@@ -159,7 +159,7 @@ export enum EnabledItemType {
   MR_SATURN = 2 ** 39,
 }
 
-export interface PreFrameUpdateType {
+export type PreFrameUpdateType = {
   frame: number | null;
   playerIndex: number | null;
   isFollower: boolean | null;
@@ -179,9 +179,9 @@ export interface PreFrameUpdateType {
   physicalRTrigger: number | null;
   rawJoystickX: number | null;
   percent: number | null;
-}
+};
 
-export interface PostFrameUpdateType {
+export type PostFrameUpdateType = {
   frame: number | null;
   playerIndex: number | null;
   isFollower: boolean | null;
@@ -206,17 +206,17 @@ export interface PostFrameUpdateType {
   selfInducedSpeeds: SelfInducedSpeedsType | null;
   hitlagRemaining: number | null;
   animationIndex: number | null;
-}
+};
 
-export interface SelfInducedSpeedsType {
+export type SelfInducedSpeedsType = {
   airX: number | null;
   y: number | null;
   attackX: number | null;
   attackY: number | null;
   groundX: number | null;
-}
+};
 
-export interface ItemUpdateType {
+export type ItemUpdateType = {
   frame: number | null;
   typeId: number | null;
   state: number | null;
@@ -233,12 +233,12 @@ export interface ItemUpdateType {
   chargeShotLaunched: number | null;
   chargePower: number | null;
   owner: number | null;
-}
+};
 
-export interface FrameBookendType {
+export type FrameBookendType = {
   frame: number | null;
   latestFinalizedFrame: number | null;
-}
+};
 
 export enum GameEndMethod {
   UNRESOLVED = 0,
@@ -249,29 +249,29 @@ export enum GameEndMethod {
   NO_CONTEST = 7,
 }
 
-export interface GameEndType {
+export type GameEndType = {
   gameEndMethod: GameEndMethod | null;
   lrasInitiatorIndex: number | null;
   placements: PlacementType[];
-}
+};
 
-export interface PlacementType {
+export type PlacementType = {
   playerIndex: number;
   position: number | null;
-}
+};
 
-export interface GeckoListType {
+export type GeckoListType = {
   codes: GeckoCodeType[];
   contents: Uint8Array;
-}
+};
 
-export interface GeckoCodeType {
+export type GeckoCodeType = {
   type: number | null;
   address: number | null;
   contents: Uint8Array;
-}
+};
 
-export interface MetadataType {
+export type MetadataType = {
   startAt?: string | null;
   playedOn?: string | null;
   lastFrame?: number | null;
@@ -287,7 +287,7 @@ export interface MetadataType {
     };
   } | null;
   consoleNick?: string | null;
-}
+};
 
 export type EventPayloadTypes =
   | GameStartType
@@ -305,7 +305,7 @@ export type EventCallbackFunc = (
   buffer?: Uint8Array | null,
 ) => boolean;
 
-export interface FrameEntryType {
+export type FrameEntryType = {
   frame: number;
   start?: FrameStartType;
   players: {
@@ -321,23 +321,23 @@ export interface FrameEntryType {
     } | null;
   };
   items?: ItemUpdateType[];
-}
+};
 
 export enum Frames {
   FIRST = -123,
   FIRST_PLAYABLE = -39,
 }
 
-export interface FramesType {
+export type FramesType = {
   [frameIndex: number]: FrameEntryType;
-}
+};
 
-export interface RollbackFramesType {
+export type RollbackFramesType = {
   [frameIndex: number]: FrameEntryType[];
-}
+};
 
-export interface RollbackFrames {
+export type RollbackFrames = {
   frames: RollbackFramesType;
   count: number;
   lengths: number[];
-}
+};

--- a/src/utils/slpFile.ts
+++ b/src/utils/slpFile.ts
@@ -11,7 +11,7 @@ import { SlpStream, SlpStreamEvent, SlpStreamMode } from "./slpStream";
 
 const DEFAULT_NICKNAME = "unknown";
 
-export interface SlpFileMetadata {
+export type SlpFileMetadata = {
   startTime: Date;
   lastFrame: number;
   players: {
@@ -26,7 +26,7 @@ export interface SlpFileMetadata {
     };
   };
   consoleNickname?: string;
-}
+};
 
 /**
  * SlpFile is a class that wraps a Writable stream. It handles the writing of the binary

--- a/src/utils/slpFileWriter.ts
+++ b/src/utils/slpFileWriter.ts
@@ -14,12 +14,12 @@ function getNewFilePath(folder: string, date: Date): string {
   return path.join(folder, `Game_${format(date, "yyyyMMdd")}T${format(date, "HHmmss")}.slp`);
 }
 
-export interface SlpFileWriterOptions extends Partial<SlpStreamSettings> {
+export type SlpFileWriterOptions = Partial<SlpStreamSettings> & {
   outputFiles: boolean;
   folderPath: string;
   consoleNickname: string;
   newFilename: (folder: string, startTime: Date) => string;
-}
+};
 
 const defaultSettings: SlpFileWriterOptions = {
   outputFiles: true,

--- a/src/utils/slpParser.ts
+++ b/src/utils/slpParser.ts
@@ -189,7 +189,6 @@ export class SlpParser extends EventEmitter {
       this._finalizeFrames(this.latestFrameIndex);
     }
 
-    payload = payload as GameEndType;
     this.gameEnd = payload;
     this.emit(SlpParserEvent.END, this.gameEnd);
   }
@@ -237,7 +236,6 @@ export class SlpParser extends EventEmitter {
   }
 
   private _handleFrameUpdate(command: Command, payload: PreFrameUpdateType | PostFrameUpdateType): void {
-    payload = payload as PostFrameUpdateType;
     const location = command === Command.PRE_FRAME_UPDATE ? "pre" : "post";
     const field = payload.isFollower ? "followers" : "players";
     const currentFrameNumber = payload.frame!;

--- a/src/utils/slpReader.ts
+++ b/src/utils/slpReader.ts
@@ -38,7 +38,7 @@ export type SlpReadInput = SlpFileReadInput | SlpBufferReadInput;
 
 export type SlpRefType = SlpFileSourceRef | SlpBufferSourceRef;
 
-export interface SlpFileType {
+export type SlpFileType = {
   ref: SlpRefType;
   rawDataPosition: number;
   rawDataLength: number;
@@ -47,16 +47,17 @@ export interface SlpFileType {
   messageSizes: {
     [command: number]: number;
   };
-}
+};
 
-export interface SlpFileSourceRef {
+export type SlpFileSourceRef = {
   source: SlpInputSource.FILE;
   fileDescriptor: number;
+};
 
-export interface SlpBufferSourceRef {
+export type SlpBufferSourceRef = {
   source: SlpInputSource.BUFFER;
   buffer: Buffer;
-}
+};
 
 function getRef(input: SlpReadInput): SlpRefType {
   switch (input.source) {

--- a/src/utils/slpReader.ts
+++ b/src/utils/slpReader.ts
@@ -236,17 +236,14 @@ function getGameInfoBlock(view: DataView): GameInfoType {
     gameBitfield3: readUint8(view, 0x2 + offset),
     gameBitfield4: readUint8(view, 0x3 + offset),
     bombRainEnabled: (readUint8(view, 0x6 + offset)! & 0xff) > 0 ? true : false,
-    itemSpawnBehavior: readInt8(view, 0xb + offset),
     selfDestructScoreValue: readInt8(view, 0xc + offset),
-    //stageId: readUint16(view, 0xe + offset),
-    //gameTimer: readUint32(view, 0x10 + offset),
     itemSpawnBitfield1: readUint8(view, 0x23 + offset),
     itemSpawnBitfield2: readUint8(view, 0x24 + offset),
     itemSpawnBitfield3: readUint8(view, 0x25 + offset),
     itemSpawnBitfield4: readUint8(view, 0x26 + offset),
     itemSpawnBitfield5: readUint8(view, 0x27 + offset),
     damageRatio: readFloat(view, 0x30 + offset),
-  } as GameInfoType;
+  };
 }
 
 /**

--- a/src/utils/slpReader.ts
+++ b/src/utils/slpReader.ts
@@ -8,6 +8,7 @@ import type {
   EventPayloadTypes,
   GameEndType,
   GameInfoType,
+  GameStartType,
   GeckoCodeType,
   MetadataType,
   PlacementType,
@@ -384,7 +385,7 @@ export function parseMessage(command: Command, payload: Uint8Array): EventPayloa
         const userId = userIdString ?? "";
 
         const offset = playerIndex * 0x24;
-        return {
+        const playerInfo: PlayerType = {
           playerIndex,
           port: playerIndex + 1,
           characterId: readUint8(view, 0x65 + offset),
@@ -412,6 +413,7 @@ export function parseMessage(command: Command, payload: Uint8Array): EventPayloa
           connectCode,
           userId,
         };
+        return playerInfo;
       };
 
       const matchIdLength = 51;
@@ -423,7 +425,7 @@ export function parseMessage(command: Command, payload: Uint8Array): EventPayloa
         .shift();
       const matchId = matchIdString ?? "";
 
-      return {
+      const gameSettings: GameStartType = {
         slpVersion: `${readUint8(view, 0x1)}.${readUint8(view, 0x2)}.${readUint8(view, 0x3)}`,
         timerType: readUint8(view, 0x5, 0x03),
         inGameMode: readUint8(view, 0x5, 0xe0),
@@ -447,6 +449,7 @@ export function parseMessage(command: Command, payload: Uint8Array): EventPayloa
           tiebreakerNumber: readUint32(view, 0x2f5),
         },
       };
+      return gameSettings;
     case Command.FRAME_START:
       return {
         frame: readInt32(view, 0x1),

--- a/src/utils/slpStream.ts
+++ b/src/utils/slpStream.ts
@@ -20,15 +20,15 @@ export type SlpStreamSettings = typeof defaultSettings;
 
 export type MessageSizes = Map<Command, number>;
 
-export interface SlpCommandEventPayload {
+export type SlpCommandEventPayload = {
   command: Command;
   payload: EventPayloadTypes | MessageSizes;
-}
+};
 
-export interface SlpRawEventPayload {
+export type SlpRawEventPayload = {
   command: Command;
   payload: Buffer;
-}
+};
 
 export enum SlpStreamEvent {
   RAW = "slp-raw",

--- a/src/utils/slpStream.ts
+++ b/src/utils/slpStream.ts
@@ -135,10 +135,11 @@ export class SlpStream extends Writable {
     const payloadBuf = entirePayload.slice(0, payloadSize);
     const bufToWrite = Buffer.concat([Buffer.from([command]), payloadBuf]);
     // Forward the raw buffer onwards
-    this.emit(SlpStreamEvent.RAW, {
+    const event: SlpRawEventPayload = {
       command: command,
       payload: bufToWrite,
-    } as SlpRawEventPayload);
+    };
+    this.emit(SlpStreamEvent.RAW, event);
     return new Uint8Array(bufToWrite);
   }
 
@@ -150,10 +151,11 @@ export class SlpStream extends Writable {
       this.payloadSizes = processReceiveCommands(dataView);
       // Emit the raw command event
       this._writeCommand(command, entirePayload, payloadSize);
-      this.emit(SlpStreamEvent.COMMAND, {
+      const eventPayload: SlpCommandEventPayload = {
         command: command,
         payload: this.payloadSizes,
-      } as SlpCommandEventPayload);
+      };
+      this.emit(SlpStreamEvent.COMMAND, eventPayload);
       return payloadSize;
     }
 
@@ -182,10 +184,11 @@ export class SlpStream extends Writable {
         break;
     }
 
-    this.emit(SlpStreamEvent.COMMAND, {
+    const eventPayload: SlpCommandEventPayload = {
       command: command,
       payload: parsedPayload,
-    } as SlpCommandEventPayload);
+    };
+    this.emit(SlpStreamEvent.COMMAND, eventPayload);
     return payloadSize;
   }
 }


### PR DESCRIPTION
### Description

This PR does the following:
- removes avoidable type castings
- prefer types over interfaces to better communicate intention and match `slippi-launcher` code style
- makes some return typing a bit more explicit

