### PR TITLE
Update getWinner() to calculate winner for legacy slps

### DIFF
--- a/src/SlippiGame.ts
+++ b/src/SlippiGame.ts
@@ -289,7 +289,9 @@ export class SlippiGame {
       finalPostFrameUpdates = extractFinalPostFrameUpdates(slpfile);
     }
 
+    const latestFrame = this.getLatestFrame();
+
     closeSlpFile(slpfile);
-    return getWinners(gameEnd, settings, finalPostFrameUpdates);
+    return getWinners(gameEnd, settings, finalPostFrameUpdates, latestFrame);
   }
 }

--- a/src/utils/getWinners.ts
+++ b/src/utils/getWinners.ts
@@ -67,10 +67,12 @@ export function getWinners(
       const p2Idx = players[1]?.playerIndex!;
       const p1Stocks = latestFrame.players[0]?.post.stocksRemaining;
       const p2Stocks = latestFrame.players[p2Idx]?.post.stocksRemaining;
-      if (p2Stocks && p2Stocks === 0 && p1Stocks && p1Stocks > 0) {
-        return [{ playerIndex: p1Idx, position: 0 }];
-      } else if (p1Stocks && p1Stocks === 0 && p2Stocks && p2Stocks > 0) {
-        return [{ playerIndex: p2Idx, position: 0 }];
+      if (p1Stocks !== undefined && p1Stocks !== null && p2Stocks !== undefined && p2Stocks !== null) {
+        if (p2Stocks === 0 && p1Stocks > 0) {
+          return [{ playerIndex: p1Idx, position: 0 }];
+        } else if (p1Stocks === 0 && p2Stocks > 0) {
+          return [{ playerIndex: p2Idx, position: 0 }];
+        }
       }
     }
   }

--- a/src/utils/getWinners.ts
+++ b/src/utils/getWinners.ts
@@ -53,6 +53,25 @@ export function getWinners(
     return [];
   }
 
+  // should only be true for legacy slps with no placements (< 3.13.0) or games without gameEnd payload
+  if (placements.every((placement) => placement.position === null) && gameEndMethod === GameEndMethod.GAME) {
+    if (players.length === 2) {
+      const p1Idx = players[0]?.playerIndex;
+      const p2Idx = players[1]?.playerIndex;
+      const p1FinalFrame = finalPostFrameUpdates.find((pfu) => pfu.playerIndex === p1Idx);
+      const p2FinalFrame = finalPostFrameUpdates.find((pfu) => pfu.playerIndex === p2Idx);
+      if (p2FinalFrame?.stocksRemaining === 0 && p1FinalFrame?.stocksRemaining && p1FinalFrame.stocksRemaining > 0) {
+        return [{ playerIndex: p1Idx ?? -1, position: 0 }];
+      } else if (
+        p1FinalFrame?.stocksRemaining === 0 &&
+        p2FinalFrame?.stocksRemaining &&
+        p2FinalFrame.stocksRemaining > 0
+      ) {
+        return [{ playerIndex: p2Idx ?? -1, position: 0 }];
+      }
+    }
+  }
+
   const firstPosition = placements.find((placement) => placement.position === 0);
   if (!firstPosition) {
     return [];


### PR DESCRIPTION
Updated getWinner() to calculate the winner of slps before 3.13.0 that don't include the positions in the gameEnd payload. Let me know if the flow makes sense or if I should reformat the code somehow. Also this only supports singles for now.