### PR TITLE
fix breaking bugs

### DIFF
--- a/dts.config.js
+++ b/dts.config.js
@@ -1,11 +1,11 @@
 module.exports = {
   rollup(config, opts) {
     if (opts.format === "esm") {
-      config = { ...config, preserveModules: true };
       config.output = {
         ...config.output,
         dir: "dist/",
         entryFileNames: "[name].esm.js",
+        preserveModules: true,
       };
       delete config.output.file;
     }

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
   ],
   "source": "./src/index.ts",
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/slippi-js.esm.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/slippi-js.esm.js",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"

--- a/src/console/communication.ts
+++ b/src/console/communication.ts
@@ -39,11 +39,14 @@ export class ConsoleCommunication {
       }
 
       // Here we have received all the data, so let's decode it
-      const ubjsonData = this.receiveBuf.slice(4, msgSize + 4);
-      this.messages.push(decode(ubjsonData.buffer));
+      const ubjsonArrayBuffer = this.receiveBuf.buffer.slice(
+        this.receiveBuf.byteOffset + 4,
+        this.receiveBuf.byteOffset + msgSize + 4,
+      );
+      this.messages.push(decode(ubjsonArrayBuffer));
 
       // Remove the processed data from receiveBuf
-      this.receiveBuf = this.receiveBuf.slice(msgSize + 4);
+      this.receiveBuf = this.receiveBuf.subarray(msgSize + 4);
     }
   }
 

--- a/src/utils/slpFile.ts
+++ b/src/utils/slpFile.ts
@@ -299,8 +299,7 @@ export class SlpFile extends Writable {
 
     // End the stream
     if (this.fileStream) {
-      this.fileStream.write(footer, callback);
-      this.fileStream.close();
+      this.fileStream.end(footer, callback);
     }
   }
 }


### PR DESCRIPTION
- update `package.json` `module` and `exports.import` to reflect changed `dts` output name (introduced in `yarn` -> `npm` and/or `dts` 1 -> 2 migration)
- properly handle offsets for underlying `ArrayBuffer` in `communication.ts` (introduced in `node` 14 -> 20 migration)

also move `preserveModules` as per deprecation in `dts.config.js` and use `fileStream.end` as proper combined write + close + callback in `slpFile.ts`