### PR TITLE
refactor: deprecate matchId and add sessionId

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -77,9 +77,12 @@ export type GameStartType = {
 };
 
 type MatchInfo = {
-  matchId: string | null;
+  sessionId: string | null;
   gameNumber: number | null;
   tiebreakerNumber: number | null;
+
+  /** @deprecated since version 7.1.1. use sessionId instead */
+  matchId: string | null;
 };
 
 export type FrameStartType = {

--- a/src/utils/slpReader.ts
+++ b/src/utils/slpReader.ts
@@ -416,14 +416,14 @@ export function parseMessage(command: Command, payload: Uint8Array): EventPayloa
         return playerInfo;
       };
 
-      const matchIdLength = 51;
-      const matchIdStart = 0x2be;
-      const matchIdBuf = payload.slice(matchIdStart, matchIdStart + matchIdLength);
-      const matchIdString = iconv
-        .decode(matchIdBuf as Buffer, "utf8")
+      const sessionIdLength = 51;
+      const sessionIdStart = 0x2be;
+      const sessionIdBuf = payload.slice(sessionIdStart, sessionIdStart + sessionIdLength);
+      const sessionIdString = iconv
+        .decode(sessionIdBuf as Buffer, "utf8")
         .split("\0")
         .shift();
-      const matchId = matchIdString ?? "";
+      const sessionId = sessionIdString ?? "";
 
       const gameSettings: GameStartType = {
         slpVersion: `${readUint8(view, 0x1)}.${readUint8(view, 0x2)}.${readUint8(view, 0x3)}`,
@@ -444,9 +444,11 @@ export function parseMessage(command: Command, payload: Uint8Array): EventPayloa
         isPAL: readBool(view, 0x1a1),
         isFrozenPS: readBool(view, 0x1a2),
         matchInfo: {
-          matchId,
+          sessionId: sessionId,
           gameNumber: readUint32(view, 0x2f1),
           tiebreakerNumber: readUint32(view, 0x2f5),
+          /** remove in v8 */
+          matchId: sessionId,
         },
       };
       return gameSettings;

--- a/test/game.spec.ts
+++ b/test/game.spec.ts
@@ -216,7 +216,7 @@ describe("when reading match info", () => {
     const matchInfo = settings?.matchInfo;
     expect(matchInfo?.gameNumber).toBe(1);
     expect(matchInfo?.tiebreakerNumber).toBe(1);
-    expect(matchInfo?.matchId).toBe("mode.ranked-2022-12-20T05:36:47.50-0");
+    expect(matchInfo?.sessionId).toBe("mode.ranked-2022-12-20T05:36:47.50-0");
   });
 
   it("should return the correct match info for unranked across multiple games", () => {
@@ -225,14 +225,14 @@ describe("when reading match info", () => {
     const matchInfoGame1 = settingsGame1?.matchInfo;
     expect(matchInfoGame1?.gameNumber).toBe(1);
     expect(matchInfoGame1?.tiebreakerNumber).toBe(0);
-    expect(matchInfoGame1?.matchId).toBe("mode.unranked-2022-12-21T02:26:27.50-0");
+    expect(matchInfoGame1?.sessionId).toBe("mode.unranked-2022-12-21T02:26:27.50-0");
 
     const game2 = new SlippiGame("slp/unranked_game2.slp");
     const settingsGame2 = game2.getSettings();
     const matchInfoGame2 = settingsGame2?.matchInfo;
     expect(matchInfoGame2?.gameNumber).toBe(2);
     expect(matchInfoGame2?.tiebreakerNumber).toBe(0);
-    expect(matchInfoGame2?.matchId).toBe(matchInfoGame1?.matchId);
+    expect(matchInfoGame2?.sessionId).toBe(matchInfoGame1?.sessionId);
   });
 
   it("should return null values for old replays", () => {
@@ -241,7 +241,7 @@ describe("when reading match info", () => {
     const matchInfo = settings?.matchInfo;
     expect(matchInfo?.gameNumber).toBe(null);
     expect(matchInfo?.tiebreakerNumber).toBe(null);
-    expect(matchInfo?.matchId).toBe("");
+    expect(matchInfo?.sessionId).toBe("");
   });
 });
 


### PR DESCRIPTION
<img width="958" height="366" alt="example showing matchId's deprecation warning" src="https://github.com/user-attachments/assets/f89a6a07-abfb-4e5f-9631-e8c232a3d39b" />
