### PR TITLE
fix: SlpFileWriter emits file-complete event before finish event

### DIFF
--- a/src/utils/slpFileWriter.ts
+++ b/src/utils/slpFileWriter.ts
@@ -131,14 +131,19 @@ export class SlpFileWriter extends SlpStream {
   private _handleEndGame(): void {
     // End the stream
     if (this.currentFile) {
+      const filePath = this.currentFile.path();
+
       // Set the console nickname
       this.currentFile.setMetadata({
         consoleNickname: this.options.consoleNickname,
       });
-      this.currentFile.end();
 
-      // console.log(`Finished writing file: ${this.currentFile.path()}`);
-      this.emit(SlpFileWriterEvent.FILE_COMPLETE, this.currentFile.path());
+      // Wait for the file to actually finish writing before emitting FILE_COMPLETE
+      this.currentFile.once("finish", () => {
+        this.emit(SlpFileWriterEvent.FILE_COMPLETE, filePath);
+      });
+
+      this.currentFile.end();
 
       // Clear current file
       this.currentFile = null;


### PR DESCRIPTION
### Description

After calling `.end()` on a file there is still some final file writing and completion logic that needs to occur. We were emitting the event immediately but it needs to actually wait for the 'finish' event to be fired for it to be correct.

This is important since it could mess up listeners of the 'file-complete' event expecting it to be actually done but isn't.
