### PR TITLE
fix: Loosen TypedEventEmitter typings

### DIFF
--- a/src/common/stats/combos.ts
+++ b/src/common/stats/combos.ts
@@ -17,11 +17,13 @@ import {
 } from "./common.js";
 import type { StatComputer } from "./stats.js";
 
-export enum ComboEvent {
-  COMBO_START = "COMBO_START",
-  COMBO_EXTEND = "COMBO_EXTEND",
-  COMBO_END = "COMBO_END",
-}
+export const ComboEvent = {
+  COMBO_START: "COMBO_START",
+  COMBO_EXTEND: "COMBO_EXTEND",
+  COMBO_END: "COMBO_END",
+} as const;
+
+export type ComboEvent = (typeof ComboEvent)[keyof typeof ComboEvent];
 
 type ComboEventData = {
   combo: ComboType | undefined;

--- a/src/common/utils/slpParser.ts
+++ b/src/common/utils/slpParser.ts
@@ -31,13 +31,15 @@ import { TypedEventEmitter } from "./typedEventEmitter.js";
 const ITEM_SETTINGS_BIT_COUNT = 40;
 export const MAX_ROLLBACK_FRAMES = 7;
 
-export enum SlpParserEvent {
-  SETTINGS = "settings",
-  END = "end",
-  FRAME = "frame", // Emitted for every frame
-  FINALIZED_FRAME = "finalized-frame", // Emitted for only finalized frames
-  ROLLBACK_FRAME = "rollback-frame", // Emitted if a frame is being replaced
-}
+export const SlpParserEvent = {
+  SETTINGS: "settings",
+  END: "end",
+  FRAME: "frame", // Emitted for every frame
+  FINALIZED_FRAME: "finalized-frame", // Emitted for only finalized frames
+  ROLLBACK_FRAME: "rollback-frame", // Emitted if a frame is being replaced
+} as const;
+
+export type SlpParserEvent = (typeof SlpParserEvent)[keyof typeof SlpParserEvent];
 
 // If strict mode is on, we will do strict validation checking
 // which could throw errors on invalid data.

--- a/src/common/utils/slpStream.ts
+++ b/src/common/utils/slpStream.ts
@@ -29,10 +29,12 @@ export type SlpRawEventPayload = {
   payload: Uint8Array;
 };
 
-export enum SlpStreamEvent {
-  RAW = "slp-raw",
-  COMMAND = "slp-command",
-}
+export const SlpStreamEvent = {
+  RAW: "slp-raw",
+  COMMAND: "slp-command",
+} as const;
+
+export type SlpStreamEvent = (typeof SlpStreamEvent)[keyof typeof SlpStreamEvent];
 
 type SlpStreamEventMap = {
   [SlpStreamEvent.RAW]: SlpRawEventPayload;

--- a/src/node/console/dolphinConnection.ts
+++ b/src/node/console/dolphinConnection.ts
@@ -7,12 +7,14 @@ import { ConnectionEvent, ConnectionStatus, Ports } from "./types.js";
 
 const MAX_PEERS = 32;
 
-export enum DolphinMessageType {
-  CONNECT_REPLY = "connect_reply",
-  GAME_EVENT = "game_event",
-  START_GAME = "start_game",
-  END_GAME = "end_game",
-}
+export const DolphinMessageType = {
+  CONNECT_REPLY: "connect_reply",
+  GAME_EVENT: "game_event",
+  START_GAME: "start_game",
+  END_GAME: "end_game",
+} as const;
+
+export type DolphinMessageType = (typeof DolphinMessageType)[keyof typeof DolphinMessageType];
 
 export class DolphinConnection extends TypedEventEmitter<ConnectionEventMap> implements Connection {
   private ipAddress: string;

--- a/src/node/console/types.ts
+++ b/src/node/console/types.ts
@@ -1,13 +1,15 @@
 import type { TypedEventEmitter } from "../../common/utils/typedEventEmitter.js";
 
-export enum ConnectionEvent {
-  CONNECT = "connect",
-  MESSAGE = "message",
-  HANDSHAKE = "handshake",
-  STATUS_CHANGE = "statusChange",
-  DATA = "data",
-  ERROR = "error",
-}
+export const ConnectionEvent = {
+  CONNECT: "connect",
+  MESSAGE: "message",
+  HANDSHAKE: "handshake",
+  STATUS_CHANGE: "statusChange",
+  DATA: "data",
+  ERROR: "error",
+} as const;
+
+export type ConnectionEvent = (typeof ConnectionEvent)[keyof typeof ConnectionEvent];
 
 export type ConnectionEventMap = {
   [ConnectionEvent.CONNECT]: undefined;


### PR DESCRIPTION
## Description

This PR fixes the issue where we are forced to use the enum when adding event emitters.

We fix it by ensuring that when we generate an event map for the `TypedEventEmitter` we're not using an actual `enum` but treating the enum as strings instead. 

### Before

It does not accept the string as a valid type for the event.

<img width="717" height="194" alt="Screenshot 2026-04-24 at 11 45 08 am" src="https://github.com/user-attachments/assets/951c6cc0-d609-4c22-abfa-3b45fb193c42" />

As a result it thinks that the data returned is `unknown`.

<img width="787" height="248" alt="Screenshot 2026-04-24 at 11 45 37 am" src="https://github.com/user-attachments/assets/e4bfe02b-89a3-42b8-acff-68f74961a560" />


### After

It correctly accepts the string for the event name, and still knows the correct type discrimination.
<img width="776" height="260" alt="Screenshot 2026-04-24 at 11 44 20 am" src="https://github.com/user-attachments/assets/a255d5a1-7b66-468d-a430-44b39657e6ad" />

<img width="806" height="209" alt="Screenshot 2026-04-24 at 11 43 36 am" src="https://github.com/user-attachments/assets/be4f0d2f-91b6-4d8c-84c2-95e5714c80cb" />
