### PR TITLE
feat: Add Ledge Grab Limit check in getWinners

### DIFF
--- a/src/common/SlippiGameBase.ts
+++ b/src/common/SlippiGameBase.ts
@@ -22,7 +22,7 @@ import type {
   RollbackFrames,
 } from "./types.js";
 import { GameMode } from "./types.js";
-import { getWinners } from "./utils/getWinners.js";
+import { type GetWinnersOptions, getWinners } from "./utils/getWinners.js";
 import { extractDistanceInfoFromFrame } from "./utils/homeRunDistance.js";
 import type { SlpInputRef } from "./utils/slpInputRef.js";
 import { SlpParser, SlpParserEvent } from "./utils/slpParser.js";
@@ -245,7 +245,7 @@ export abstract class SlippiGameBase {
 
   abstract getFilePath(): string | undefined;
 
-  getWinners(): PlacementType[] {
+  getWinners(options?: { ledgeGrabLimit?: number }): PlacementType[] {
     this.input.open();
     const slpfile = openSlpFile(this.input);
     this._process(() => this.parser.getSettings() != null, slpfile);
@@ -258,6 +258,19 @@ export abstract class SlippiGameBase {
     const finalPostFrameUpdates = extractFinalPostFrameUpdates(slpfile);
     const gameEnd: Partial<GameEndType> = getGameEnd(slpfile) ?? {};
     this.input.close();
-    return getWinners(gameEnd, settings, finalPostFrameUpdates);
+
+    let getWinnersOpts: GetWinnersOptions | undefined;
+    if (options?.ledgeGrabLimit) {
+      const stats = this.getStats();
+      const ledgeGrabCounts: Record<number, number> = {};
+      if (stats?.actionCounts) {
+        for (const ac of stats.actionCounts) {
+          ledgeGrabCounts[ac.playerIndex] = ac.ledgegrabCount;
+        }
+      }
+      getWinnersOpts = { ledgeGrabLimit: options.ledgeGrabLimit, ledgeGrabCounts };
+    }
+
+    return getWinners(gameEnd, settings, finalPostFrameUpdates, getWinnersOpts);
   }
 }

--- a/src/common/utils/getWinners.test.ts
+++ b/src/common/utils/getWinners.test.ts
@@ -1,5 +1,6 @@
 import { SlippiGame } from "../../node/index";
-import type { FramesType, GameEndType, PostFrameUpdateType } from "../types";
+import type { FramesType, GameEndType, GameStartType, PostFrameUpdateType } from "../types";
+import { GameEndMethod } from "../types";
 import { getWinners } from "./getWinners";
 
 function getLastFrameUpdates(game: SlippiGame): PostFrameUpdateType[] {
@@ -96,6 +97,150 @@ describe("getWinners", () => {
       expect(winners).toHaveLength(1);
       expect(winners[0]!.playerIndex).toBe(3);
       expect(winners[0]!.position).toBe(0);
+    });
+  });
+
+  describe("ledge grab limit", () => {
+    const baseSettings = {
+      players: [
+        { playerIndex: 0 } as GameStartType["players"][number],
+        { playerIndex: 1 } as GameStartType["players"][number],
+      ],
+      isTeams: false,
+    };
+
+    const basePostFrameUpdates = [
+      { playerIndex: 0, stocksRemaining: 2, percent: 50, isFollower: false },
+      { playerIndex: 1, stocksRemaining: 1, percent: 100, isFollower: false },
+    ] as PostFrameUpdateType[];
+
+    it("should disqualify a player who exceeds the ledge grab limit in a timeout 1v1", () => {
+      const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      const winners = getWinners(gameEnd, baseSettings, basePostFrameUpdates, {
+        ledgeGrabLimit: 5,
+        ledgeGrabCounts: { 0: 8, 1: 2 },
+      });
+
+      expect(winners).toHaveLength(1);
+      expect(winners[0]!.playerIndex).toBe(1);
+      expect(winners[0]!.position).toBe(0);
+    });
+
+    it("should return a draw when both players exceed the ledge grab limit", () => {
+      const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      const winners = getWinners(gameEnd, baseSettings, basePostFrameUpdates, {
+        ledgeGrabLimit: 5,
+        ledgeGrabCounts: { 0: 8, 1: 6 },
+      });
+
+      expect(winners).toHaveLength(0);
+    });
+
+    it("should return normal winner when neither player exceeds the limit", () => {
+      const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      const winners = getWinners(gameEnd, baseSettings, basePostFrameUpdates, {
+        ledgeGrabLimit: 10,
+        ledgeGrabCounts: { 0: 3, 1: 5 },
+      });
+
+      expect(winners).toHaveLength(1);
+      expect(winners[0]!.playerIndex).toBe(0);
+      expect(winners[0]!.position).toBe(0);
+    });
+
+    it("should not apply the ledge grab limit when game did not end by time", () => {
+      const gameEnd: Partial<GameEndType> = {
+        gameEndMethod: GameEndMethod.GAME,
+        placements: [{ playerIndex: 0, position: 0 }],
+      };
+      const winners = getWinners(gameEnd, baseSettings, basePostFrameUpdates, {
+        ledgeGrabLimit: 5,
+        ledgeGrabCounts: { 0: 8, 1: 2 },
+      });
+
+      expect(winners).toHaveLength(1);
+      expect(winners[0]!.playerIndex).toBe(0);
+      expect(winners[0]!.position).toBe(0);
+    });
+
+    it("should not apply the ledge grab limit in teams mode", () => {
+      const teamsSettings = {
+        players: [
+          { playerIndex: 0, teamId: 0 } as GameStartType["players"][number],
+          { playerIndex: 1, teamId: 0 } as GameStartType["players"][number],
+        ],
+        isTeams: true,
+      };
+      const teamsPostFrameUpdates = [
+        { playerIndex: 0, stocksRemaining: 1, percent: 0, isFollower: false },
+        { playerIndex: 1, stocksRemaining: 1, percent: 0, isFollower: false },
+      ] as PostFrameUpdateType[];
+      const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      const winners = getWinners(gameEnd, teamsSettings, teamsPostFrameUpdates, {
+        ledgeGrabLimit: 5,
+        ledgeGrabCounts: { 0: 8, 1: 2 },
+      });
+
+      // Should still use normal teams logic (both on same team = 2 winners)
+      expect(winners).toHaveLength(2);
+    });
+
+    it("should treat limit of 0 as no limit", () => {
+      const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      const winners = getWinners(gameEnd, baseSettings, basePostFrameUpdates, {
+        ledgeGrabLimit: 0,
+        ledgeGrabCounts: { 0: 8, 1: 2 },
+      });
+
+      expect(winners).toHaveLength(1);
+      expect(winners[0]!.playerIndex).toBe(0);
+      expect(winners[0]!.position).toBe(0);
+    });
+
+    it("should treat negative limit as no limit", () => {
+      const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      const winners = getWinners(gameEnd, baseSettings, basePostFrameUpdates, {
+        ledgeGrabLimit: -1,
+        ledgeGrabCounts: { 0: 8, 1: 2 },
+      });
+
+      expect(winners).toHaveLength(1);
+      expect(winners[0]!.playerIndex).toBe(0);
+      expect(winners[0]!.position).toBe(0);
+    });
+
+    it("should not affect result when no ledgeGrabCounts are provided", () => {
+      const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      const winners = getWinners(gameEnd, baseSettings, basePostFrameUpdates, {
+        ledgeGrabLimit: 5,
+      });
+
+      expect(winners).toHaveLength(1);
+      expect(winners[0]!.playerIndex).toBe(0);
+      expect(winners[0]!.position).toBe(0);
+    });
+
+    it("should not affect result when there are more than 2 players", () => {
+      const ffaSettings = {
+        players: [
+          { playerIndex: 0 } as GameStartType["players"][number],
+          { playerIndex: 1 } as GameStartType["players"][number],
+          { playerIndex: 2 } as GameStartType["players"][number],
+        ],
+        isTeams: false,
+      };
+      const ffaPostFrameUpdates = [
+        { playerIndex: 0, stocksRemaining: 1, percent: 0, isFollower: false },
+        { playerIndex: 1, stocksRemaining: 1, percent: 0, isFollower: false },
+        { playerIndex: 2, stocksRemaining: 1, percent: 0, isFollower: false },
+      ] as PostFrameUpdateType[];
+      const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      const winners = getWinners(gameEnd, ffaSettings, ffaPostFrameUpdates, {
+        ledgeGrabLimit: 5,
+        ledgeGrabCounts: { 0: 8, 1: 2, 2: 1 },
+      });
+
+      expect(winners).toHaveLength(3);
     });
   });
 });

--- a/src/common/utils/getWinners.test.ts
+++ b/src/common/utils/getWinners.test.ts
@@ -126,14 +126,16 @@ describe("getWinners", () => {
       expect(winners[0]!.position).toBe(0);
     });
 
-    it("should return a draw when both players exceed the ledge grab limit", () => {
+    it("should disregard the rule when both players exceed the ledge grab limit and return original winners", () => {
       const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
       const winners = getWinners(gameEnd, baseSettings, basePostFrameUpdates, {
         ledgeGrabLimit: 5,
         ledgeGrabCounts: { 0: 8, 1: 6 },
       });
 
-      expect(winners).toHaveLength(0);
+      expect(winners).toHaveLength(1);
+      expect(winners[0]!.playerIndex).toBe(0);
+      expect(winners[0]!.position).toBe(0);
     });
 
     it("should return normal winner when neither player exceeds the limit", () => {
@@ -163,26 +165,93 @@ describe("getWinners", () => {
       expect(winners[0]!.position).toBe(0);
     });
 
-    it("should not apply the ledge grab limit in teams mode", () => {
+    it("should disqualify a team when a player on it exceeds the limit", () => {
       const teamsSettings = {
         players: [
           { playerIndex: 0, teamId: 0 } as GameStartType["players"][number],
           { playerIndex: 1, teamId: 0 } as GameStartType["players"][number],
+          { playerIndex: 2, teamId: 1 } as GameStartType["players"][number],
+          { playerIndex: 3, teamId: 1 } as GameStartType["players"][number],
         ],
         isTeams: true,
       };
       const teamsPostFrameUpdates = [
-        { playerIndex: 0, stocksRemaining: 1, percent: 0, isFollower: false },
-        { playerIndex: 1, stocksRemaining: 1, percent: 0, isFollower: false },
+        { playerIndex: 0, stocksRemaining: 2, percent: 0, isFollower: false },
+        { playerIndex: 1, stocksRemaining: 2, percent: 0, isFollower: false },
+        { playerIndex: 2, stocksRemaining: 1, percent: 0, isFollower: false },
+        { playerIndex: 3, stocksRemaining: 1, percent: 0, isFollower: false },
       ] as PostFrameUpdateType[];
       const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      // Team 0 (players 0,1) wins on stocks, but player 0 exceeds limit
       const winners = getWinners(gameEnd, teamsSettings, teamsPostFrameUpdates, {
         ledgeGrabLimit: 5,
-        ledgeGrabCounts: { 0: 8, 1: 2 },
+        ledgeGrabCounts: { 0: 8, 1: 2, 2: 1, 3: 3 },
       });
 
-      // Should still use normal teams logic (both on same team = 2 winners)
+      // Team 1 (players 2,3) should win
       expect(winners).toHaveLength(2);
+      expect(winners[0]!.playerIndex).toBe(2);
+      expect(winners[0]!.position).toBe(0);
+      expect(winners[1]!.playerIndex).toBe(3);
+      expect(winners[1]!.position).toBe(0);
+    });
+
+    it("should disregard the rule when both teams have a player that exceeds the limit", () => {
+      const teamsSettings = {
+        players: [
+          { playerIndex: 0, teamId: 0 } as GameStartType["players"][number],
+          { playerIndex: 1, teamId: 0 } as GameStartType["players"][number],
+          { playerIndex: 2, teamId: 1 } as GameStartType["players"][number],
+          { playerIndex: 3, teamId: 1 } as GameStartType["players"][number],
+        ],
+        isTeams: true,
+      };
+      const teamsPostFrameUpdates = [
+        { playerIndex: 0, stocksRemaining: 2, percent: 0, isFollower: false },
+        { playerIndex: 1, stocksRemaining: 2, percent: 0, isFollower: false },
+        { playerIndex: 2, stocksRemaining: 1, percent: 0, isFollower: false },
+        { playerIndex: 3, stocksRemaining: 1, percent: 0, isFollower: false },
+      ] as PostFrameUpdateType[];
+      const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      // Both teams have at least one exceeding player
+      const winners = getWinners(gameEnd, teamsSettings, teamsPostFrameUpdates, {
+        ledgeGrabLimit: 5,
+        ledgeGrabCounts: { 0: 8, 1: 2, 2: 6, 3: 3 },
+      });
+
+      // Disregard → original stock/percent winners (Team 0)
+      expect(winners).toHaveLength(2);
+      expect(winners[0]!.playerIndex).toBe(0);
+      expect(winners[1]!.playerIndex).toBe(1);
+    });
+
+    it("should disregard the rule when no team has a player that exceeds the limit", () => {
+      const teamsSettings = {
+        players: [
+          { playerIndex: 0, teamId: 0 } as GameStartType["players"][number],
+          { playerIndex: 1, teamId: 0 } as GameStartType["players"][number],
+          { playerIndex: 2, teamId: 1 } as GameStartType["players"][number],
+          { playerIndex: 3, teamId: 1 } as GameStartType["players"][number],
+        ],
+        isTeams: true,
+      };
+      const teamsPostFrameUpdates = [
+        { playerIndex: 0, stocksRemaining: 2, percent: 0, isFollower: false },
+        { playerIndex: 1, stocksRemaining: 2, percent: 0, isFollower: false },
+        { playerIndex: 2, stocksRemaining: 1, percent: 0, isFollower: false },
+        { playerIndex: 3, stocksRemaining: 1, percent: 0, isFollower: false },
+      ] as PostFrameUpdateType[];
+      const gameEnd: Partial<GameEndType> = { gameEndMethod: GameEndMethod.TIME };
+      // No one exceeds
+      const winners = getWinners(gameEnd, teamsSettings, teamsPostFrameUpdates, {
+        ledgeGrabLimit: 5,
+        ledgeGrabCounts: { 0: 2, 1: 3, 2: 1, 3: 4 },
+      });
+
+      // Disregard → original stock/percent winners (Team 0)
+      expect(winners).toHaveLength(2);
+      expect(winners[0]!.playerIndex).toBe(0);
+      expect(winners[1]!.playerIndex).toBe(1);
     });
 
     it("should treat limit of 0 as no limit", () => {

--- a/src/common/utils/getWinners.ts
+++ b/src/common/utils/getWinners.ts
@@ -73,11 +73,8 @@ export function getWinners(
     (!gameEndMethod || gameEndMethod === GameEndMethod.TIME) && activePlayers.length >= 2;
 
   if (shouldDetermineFromLastFrame) {
-    if (isTeams) {
-      return getTeamsWinners(players, activePlayers);
-    }
-    const winners = getFFAWinners(activePlayers);
-    return applyLedgeGrabLimit(winners, players, gameEndMethod, options);
+    const winners = isTeams ? getTeamsWinners(players, activePlayers) : getFFAWinners(activePlayers);
+    return applyLedgeGrabLimit(winners, players, gameEndMethod, isTeams, options);
   }
 
   // ==========================================================================
@@ -244,13 +241,10 @@ function applyLedgeGrabLimit(
   winners: PlacementType[],
   players: GameStartType["players"],
   gameEndMethod: GameEndMethod | undefined,
+  isTeams: boolean | undefined,
   options?: GetWinnersOptions,
 ): PlacementType[] {
   if (gameEndMethod !== GameEndMethod.TIME) {
-    return winners;
-  }
-
-  if (players.length !== 2) {
     return winners;
   }
 
@@ -263,18 +257,35 @@ function applyLedgeGrabLimit(
     return winners;
   }
 
-  // Check if any winner exceeded the limit
+  if (isTeams) {
+    return applyTeamLedgeGrabLimit(winners, players, ledgeGrabLimit, ledgeGrabCounts);
+  }
+
+  // Non-teams: only apply to 1v1 (exactly 2 players)
+  if (players.length !== 2) {
+    return winners;
+  }
+
+  return applyOneVOneLedgeGrabLimit(winners, players, ledgeGrabLimit, ledgeGrabCounts);
+}
+
+function applyOneVOneLedgeGrabLimit(
+  winners: PlacementType[],
+  players: GameStartType["players"],
+  ledgeGrabLimit: number,
+  ledgeGrabCounts: Record<number, number>,
+): PlacementType[] {
   const winnersExceeding = winners.filter((w) => (ledgeGrabCounts[w.playerIndex] ?? 0) > ledgeGrabLimit);
 
   if (winnersExceeding.length === 0) {
     return winners;
   }
 
-  // If all players exceeded the limit, it's a draw
+  // If all players exceeded, disregard the rule (return original stock/percent winners)
   const allPlayersExceed = players.every((p) => (ledgeGrabCounts[p.playerIndex] ?? 0) > ledgeGrabLimit);
 
   if (allPlayersExceed) {
-    return [];
+    return winners;
   }
 
   // At least one non-exceeding player exists - they win
@@ -284,4 +295,42 @@ function applyLedgeGrabLimit(
     playerIndex: p.playerIndex,
     position: 0,
   }));
+}
+
+function applyTeamLedgeGrabLimit(
+  winners: PlacementType[],
+  players: GameStartType["players"],
+  ledgeGrabLimit: number,
+  ledgeGrabCounts: Record<number, number>,
+): PlacementType[] {
+  // Group players by team and determine which teams have exceeding members
+  const teamPlayers = new Map<number, GameStartType["players"]>();
+  const teamsExceeding = new Set<number>();
+
+  for (const p of players) {
+    const teamId = p.teamId ?? -1;
+    const existing = teamPlayers.get(teamId) ?? [];
+    teamPlayers.set(teamId, [...existing, p]);
+
+    if ((ledgeGrabCounts[p.playerIndex] ?? 0) > ledgeGrabLimit) {
+      teamsExceeding.add(teamId);
+    }
+  }
+
+  // If no teams exceed, or all teams exceed, disregard the rule
+  if (teamsExceeding.size === 0 || teamsExceeding.size === teamPlayers.size) {
+    return winners;
+  }
+
+  // Non-exceeding teams win
+  const nonExceedingTeamIds = [...teamPlayers.keys()].filter((tid) => !teamsExceeding.has(tid));
+
+  return nonExceedingTeamIds
+    .flatMap((tid) =>
+      (teamPlayers.get(tid) ?? []).map((p) => ({
+        playerIndex: p.playerIndex,
+        position: 0,
+      })),
+    )
+    .sort((a, b) => a.playerIndex - b.playerIndex);
 }

--- a/src/common/utils/getWinners.ts
+++ b/src/common/utils/getWinners.ts
@@ -8,10 +8,16 @@ type TeamAggregate = {
   players: PostFrameUpdateType[];
 };
 
+export type GetWinnersOptions = {
+  ledgeGrabLimit?: number;
+  ledgeGrabCounts?: Record<number, number>;
+};
+
 export function getWinners(
   gameEnd: Partial<GameEndType>,
   settings: Pick<GameStartType, "players" | "isTeams">,
   finalPostFrameUpdates: PostFrameUpdateType[],
+  options?: GetWinnersOptions,
 ): PlacementType[] {
   const { placements, gameEndMethod, lrasInitiatorIndex } = gameEnd;
   const { players, isTeams } = settings;
@@ -70,7 +76,8 @@ export function getWinners(
     if (isTeams) {
       return getTeamsWinners(players, activePlayers);
     }
-    return getFFAWinners(activePlayers);
+    const winners = getFFAWinners(activePlayers);
+    return applyLedgeGrabLimit(winners, players, gameEndMethod, options);
   }
 
   // ==========================================================================
@@ -231,4 +238,50 @@ function sortByPerformance(players: PostFrameUpdateType[]): PostFrameUpdateType[
     }
     return (a.percent ?? 0) - (b.percent ?? 0);
   });
+}
+
+function applyLedgeGrabLimit(
+  winners: PlacementType[],
+  players: GameStartType["players"],
+  gameEndMethod: GameEndMethod | undefined,
+  options?: GetWinnersOptions,
+): PlacementType[] {
+  if (gameEndMethod !== GameEndMethod.TIME) {
+    return winners;
+  }
+
+  if (players.length !== 2) {
+    return winners;
+  }
+
+  const { ledgeGrabLimit, ledgeGrabCounts } = options ?? {};
+  if (!ledgeGrabLimit || ledgeGrabLimit <= 0 || !ledgeGrabCounts) {
+    return winners;
+  }
+
+  if (winners.length === 0) {
+    return winners;
+  }
+
+  // Check if any winner exceeded the limit
+  const winnersExceeding = winners.filter((w) => (ledgeGrabCounts[w.playerIndex] ?? 0) > ledgeGrabLimit);
+
+  if (winnersExceeding.length === 0) {
+    return winners;
+  }
+
+  // If all players exceeded the limit, it's a draw
+  const allPlayersExceed = players.every((p) => (ledgeGrabCounts[p.playerIndex] ?? 0) > ledgeGrabLimit);
+
+  if (allPlayersExceed) {
+    return [];
+  }
+
+  // At least one non-exceeding player exists - they win
+  const nonExceedingPlayers = players.filter((p) => (ledgeGrabCounts[p.playerIndex] ?? 0) <= ledgeGrabLimit);
+
+  return nonExceedingPlayers.map((p) => ({
+    playerIndex: p.playerIndex,
+    position: 0,
+  }));
 }


### PR DESCRIPTION
### Description

Adds an optional Ledge Grab Limit rule to the `getWinners` function and `SlippiGameBase.getWinners()` API, following tournament rulesets that disqualify players who exceed a maximum number of ledge grabs (Cliffhangers) during time-out games.

When enabled, if a player exceeds the specified limit in a time-out game, they forfeit. If all players (or all teams) exceed the limit, the rule is disregarded and the original stock/percent winner is returned.

We only handle the time-out game case. Non-timeout ledge grab limit checks can be delegated to the caller using action stat counts.

### High-level usage (via `SlippiGameBase`)

```ts
game.getWinners({ ledgeGrabLimit: 40 });
// Internally fetches stats to extract ledgegrabCount from actionCounts
```

### Behavior summary

| Scenario | Result |
|---|---|
| 1v1: winner exceeds limit | Non-exceeding player wins |
| 1v1: both exceed | Disregarded — original stock winner returned |
| 1v1: neither exceeds | Original stock winner returned |
| Teams: one team has exceeding member | Other team wins |
| Teams: both teams have exceeding members | Disregarded — original winners returned |
| FFA 3+, non-timeout, teams with no exceeders | Limit ignored / disregarded |



### Discussion

Currently this logic only applies on games explicitly ending in TIME, since this was the traditional/original LGL rule. However, recently tournaments have added unconditional LGL (i.e. takes effect even when the game does not end in time). This rule has potentially existed from as early as March 2025, as can be seen in the [Nouns Rulebook](https://docs.google.com/document/d/1vlma5v_FnUKpfiRIPVj3-HfvB6_qt6QSwQWABky94R4/edit?tab=t.0). For a recent/upcoming example, see [Supernova 2026 Ruleset](https://docs.google.com/document/d/1w6SDL0jvtRSkO9nNFmDIB__siuiLvZLuujorcXNS1D8/edit?tab=t.0) below.

<img width="565" height="482" alt="Screenshot 2026-06-16 at 6 43 20 pm" src="https://github.com/user-attachments/assets/baa47c9d-6085-4657-bb9b-7cd81540d82a" />


Should we have the logic always check for LGL (if the option is passed in)? Then if the user only wants a certain LGL they can check the game end type themselves and pass the correct LGL in when calling `getWinners`.
If we check the LGL rule unconditionally when provided as an option, it would provide the caller with more flexibility.